### PR TITLE
Adding other Ace colouration

### DIFF
--- a/frontend/buffers/editor.js
+++ b/frontend/buffers/editor.js
@@ -119,6 +119,11 @@ export const Editor = EpicComponent(self => {
 
   const changeMode = function(mode)
   {
+        const url = window.location;
+        const path = url.pathname;
+        const searchParams = new URLSearchParams(url.search);
+        searchParams.set("editorLanguage",mode);
+        window.history.replaceState({}, "", path+"?"+searchParams.toString());
         wrapModelToEditor(function () {
           editor.session.setMode(`ace/mode/${mode}`);
         });

--- a/frontend/buffers/editor.js
+++ b/frontend/buffers/editor.js
@@ -117,6 +117,13 @@ export const Editor = EpicComponent(self => {
     });
   };
 
+  const changeMode = function(mode)
+  {
+        wrapModelToEditor(function () {
+          editor.session.setMode(`ace/mode/${mode}`);
+        });
+  };
+
   const applyDeltas = function (deltas) {
     wrapModelToEditor(function () {
       editor.session.doc.applyDeltas(deltas);
@@ -182,7 +189,7 @@ export const Editor = EpicComponent(self => {
     editor.setReadOnly(self.props.readOnly);
     const {onInit, onSelect, onEdit, onScroll} = self.props;
     if (typeof onInit === 'function') {
-      const api = {reset, applyDeltas, setSelection, focus, scrollToLine, getSelectionRange, highlight};
+      const api = {reset, changeMode, applyDeltas, setSelection, focus, scrollToLine, getSelectionRange, highlight};
       onInit(api);
     }
     if (typeof onSelect === 'function') {

--- a/frontend/buffers/index.js
+++ b/frontend/buffers/index.js
@@ -34,6 +34,10 @@ import EpicComponent from 'epic-component';
 
 import 'brace';
 import 'brace/mode/c_cpp';
+import 'brace/mode/python';
+import 'brace/mode/java';
+
+
 import 'brace/theme/textmate';
 import 'brace/worker/javascript';
 import '../arduino/ace';
@@ -61,6 +65,8 @@ export default function (bundle, deps) {
   bundle.defineAction('bufferModelSelect', 'Buffer.Model.Select');
   bundle.defineAction('bufferModelScroll', 'Buffer.Model.Scroll');
   bundle.defineAction('bufferHighlight', 'Buffer.Highlight');
+  bundle.defineAction('bufferChangeMode', 'Buffer.ChangeMode');
+
 
   bundle.defineSelector('getBufferModel', function (state, buffer) {
     return state.getIn(['buffers', buffer, 'model']);
@@ -115,6 +121,7 @@ export default function (bundle, deps) {
     return state.setIn(['buffers', buffer, 'model', 'firstVisibleRow'], firstVisibleRow);
   }
 
+
   bundle.addSaga(function* watchBuffers () {
     yield takeEvery(deps.bufferInit, function* (action) {
       const {buffer, editor} = action;
@@ -158,6 +165,13 @@ export default function (bundle, deps) {
       const editor = yield select(getBufferEditor, buffer);
       if (editor) {
         editor.highlight(range);
+      }
+    });
+    yield takeEvery(deps.bufferChangeMode, function* (action) {
+      const {buffer, mode} = action;
+      const editor = yield select(getBufferEditor, buffer);
+      if (editor) {
+        editor.changeMode(mode);
       }
     });
   });

--- a/frontend/buffers/index.js
+++ b/frontend/buffers/index.js
@@ -32,6 +32,7 @@ import Immutable from 'immutable';
 import React from 'react';
 import EpicComponent from 'epic-component';
 
+//Import new modes here then add them to the list in common/aceMode.js
 import 'brace';
 import 'brace/mode/c_cpp';
 import 'brace/mode/python';
@@ -66,6 +67,7 @@ export default function (bundle, deps) {
   bundle.defineAction('bufferModelScroll', 'Buffer.Model.Scroll');
   bundle.defineAction('bufferHighlight', 'Buffer.Highlight');
   bundle.defineAction('bufferChangeMode', 'Buffer.ChangeMode');
+  bundle.defineAction('bufferLanguageConfigure', 'Buffer.Language.Configure');
 
 
   bundle.defineSelector('getBufferModel', function (state, buffer) {
@@ -120,6 +122,19 @@ export default function (bundle, deps) {
     const {buffer, firstVisibleRow} = action;
     return state.setIn(['buffers', buffer, 'model', 'firstVisibleRow'], firstVisibleRow);
   }
+
+
+  bundle.addReducer('bufferLanguageConfigure', bufferLanguageConfigure);
+  function bufferLanguageConfigure(state, action)
+  {
+    const {options} = action;
+    return state.set("bufferLanguage.options", options);
+  }
+
+  bundle.defineSelector('getBufferLanguageOptions', state =>
+       state.get('bufferLanguage.options')
+  );
+   
 
 
   bundle.addSaga(function* watchBuffers () {

--- a/frontend/common/aceMode.js
+++ b/frontend/common/aceMode.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import EpicComponent from 'epic-component';
+import Select from 'react-select';
+
+
+export default function (bundle, deps) {
+
+	bundle.use('bufferChangeMode');
+
+	function modePickerSelector (state, props) {
+    return;
+  }
+
+  bundle.defineView('ModePicker', modePickerSelector, class ModePicker extends React.PureComponent {
+
+    render () {
+      const exampleOptions =  [{label : "C++", value: "c_cpp"}, {label : "Python", value:"python"}, {label : "Java", value:"java"}]
+      return <Select options={exampleOptions} onChange={this.onSelect} clearableValue={false} />;
+    }
+
+    onSelect = (option) => {
+      this.props.dispatch({type: deps.bufferChangeMode, buffer: 'source', mode: option.value});
+    };
+
+  });
+
+
+
+
+};

--- a/frontend/common/aceMode.js
+++ b/frontend/common/aceMode.js
@@ -2,20 +2,46 @@ import React from 'react';
 import EpicComponent from 'epic-component';
 import Select from 'react-select';
 
+//Modes should be imported in buffers/index.js
+//Label is the name you want to show in the list for the user, value is the name of the mode for Ace
+const modes =  [{label : "C++", value: "c_cpp"}, {label : "Python", value:"python"}, {label : "Java", value:"java"}];
 
 export default function (bundle, deps) {
 
 	bundle.use('bufferChangeMode');
 
+  bundle.addReducer('init', state => state.set('aceModes', modes));
+  bundle.addReducer('init', setAutoMode);
+  function setAutoMode(state)
+  {
+    var authorisedAceMode = {};
+    for (var i = modes.length - 1; i >= 0; i--) {
+      authorisedAceMode[modes[i].value] = true;
+    }
+
+    console.log(authorisedAceMode);
+    return state.set("authorisedAceMode", authorisedAceMode);
+  }
+
+  bundle.defineSelector('getAceModesList', function (state) {
+    return state.getIn(['aceModes']);
+  });
+
+  bundle.defineSelector('getAuthorisedAceModesList', function (state) {
+    return state.get('authorisedAceMode');
+  });
+
+
 	function modePickerSelector (state, props) {
-    return;
+    const aceModes = deps.getAceModesList(state);
+    return {aceModes};
   }
 
   bundle.defineView('ModePicker', modePickerSelector, class ModePicker extends React.PureComponent {
 
     render () {
-      const exampleOptions =  [{label : "C++", value: "c_cpp"}, {label : "Python", value:"python"}, {label : "Java", value:"java"}]
-      return <Select options={exampleOptions} onChange={this.onSelect} clearableValue={false} />;
+      const {aceModes} = this.props;
+      return <Select options={modes} onChange={this.onSelect} clearableValue={false} />;
     }
 
     onSelect = (option) => {

--- a/frontend/common/index.js
+++ b/frontend/common/index.js
@@ -10,6 +10,7 @@ import buffers from '../buffers/index';
 import errors from './errors';
 import resize from './resize';
 import MenuBundle from './menu';
+import aceMode from "./aceMode";
 import examples from './examples';
 import ArduinoBundle from '../arduino/index';
 import ReplayBundle from '../player/replay';
@@ -36,6 +37,7 @@ export default function (bundle) {
   bundle.include(resize);
   bundle.include(MenuBundle);
   bundle.include(examples);
+  bundle.include(aceMode);
   bundle.include(ArduinoBundle);
   bundle.include(require('./login'));
   bundle.include(require('./client_api'));

--- a/frontend/common/main_view.js
+++ b/frontend/common/main_view.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {Button, Panel} from 'react-bootstrap';
 import classnames from 'classnames';
+import {modes} from "./aceMode.js"
 
 class MainView extends React.PureComponent {
   render () {
@@ -97,10 +98,11 @@ export default function (bundle, deps) {
     'getTranslateDiagnostics', 'getStepperDisplay', 'getStepperOptions',
     'translateClearDiagnostics', 'stepperExit',
     'BufferEditor', 'StackView', 'DirectivesPane', 'IOPane',
-    'ArduinoConfigPanel', 'ArduinoPanel'
+    'ArduinoConfigPanel', 'ArduinoPanel', "getAuthorisedAceModesList"
   );
 
   function MainViewSelector (state, props) {
+    //console.log(modes);
     const getMessage = state.get('getMessage');
     const geometry = state.get('mainViewGeometry');
     const panes = state.get('panes');
@@ -112,8 +114,12 @@ export default function (bundle, deps) {
     const options = deps.getStepperOptions(state);
     const {translateClearDiagnostics, stepperExit} = deps;
     const arduinoEnabled = options.get('arduino');
+    const authorisedLang = deps.getAuthorisedAceModesList(state);
+    const setLang = state.get('bufferLanguage.options');
+
+    const lang = (setLang in authorisedLang) ? setLang  : "c_cpp";
     const sourceRowHeight = '300px';
-    const sourceMode = arduinoEnabled ? 'arduino' : 'c_cpp';
+    const sourceMode = arduinoEnabled ? 'arduino' : lang;
     return {
       diagnostics, haveStepper, readOnly, error, options, getMessage, geometry, panes,
       translateClearDiagnostics, stepperExit,

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -60,6 +60,7 @@ Codecast.start = function (options) {
 
   const qs = queryString.parse(window.location.search);
 
+
   const stepperOptions = {
     showStepper: true,
     showStack: true,
@@ -90,6 +91,11 @@ Codecast.start = function (options) {
     stepperOptions.showIO = false;
   }
   store.dispatch({type: scope.stepperConfigure, options: stepperOptions});
+
+  if ('editorLanguage' in qs)
+  {
+    store.dispatch({type: scope.bufferLanguageConfigure, options: qs.editorLanguage||''});
+  }
 
   /* Source code from options or URL */
   if ('source' in options) {

--- a/frontend/sandbox/index.js
+++ b/frontend/sandbox/index.js
@@ -8,7 +8,7 @@ export default function (bundle, deps) {
 
 class SandboxApp extends React.PureComponent {
   render () {
-    const {StepperControls, Menu, MainView, MainViewPanes, containerWidth, viewportTooSmall} = this.props;
+    const {StepperControls, Menu, MainView, MainViewPanes, containerWidth, viewportTooSmall, ModePicker} = this.props;
     return (
       <div id='main' style={{width: `${containerWidth}px`}} className={classnames([viewportTooSmall && 'viewportTooSmall'])}>
         <div id='player-controls'>
@@ -18,6 +18,7 @@ class SandboxApp extends React.PureComponent {
               <StepperControls enabled={true}/>
             </div>
             <div className="player-controls player-controls-right col-sm-2">
+              <ModePicker/>
               <Menu/>
             </div>
           </div>
@@ -32,11 +33,11 @@ class SandboxApp extends React.PureComponent {
 }
 
 function SandboxAppSelector (state) {
-  const {StepperControls, Menu, MainView, MainViewPanes} = state.get('scope');
+  const {StepperControls, Menu, MainView, MainViewPanes, ModePicker} = state.get('scope');
   const containerWidth = state.get('containerWidth');
   const viewportTooSmall = state.get('viewportTooSmall');
   return {
     viewportTooSmall, containerWidth,
-    StepperControls, Menu, MainView, MainViewPanes
+    StepperControls, Menu, MainView, MainViewPanes, ModePicker
   };
 }

--- a/frontend/sandbox/index.js
+++ b/frontend/sandbox/index.js
@@ -18,7 +18,6 @@ class SandboxApp extends React.PureComponent {
               <StepperControls enabled={true}/>
             </div>
             <div className="player-controls player-controls-right col-sm-2">
-              <ModePicker/>
               <Menu/>
             </div>
           </div>


### PR DESCRIPTION

This pull request aim to add others syntaxical coloration into the project instead of being limited to C++.
As such, it add two things :
It search for a parameter "editorLanguage" in the get payload, and compare it to the known language. If a match is found, it will use this colouration instead of the default one (c++).

I added a menu that allow the user to choose the language he wants to use. When a choice is made, it updates the url of the page to add it into the payload. In this PR the menu is initially deactivated and it need to be added back in a way that fit into the project's graphical design.


It was made under the direction of Mr Sharrock for an engineer school project.