### PR TITLE
"enable" typescript strictness

### DIFF
--- a/frontend/buffers/index.ts
+++ b/frontend/buffers/index.ts
@@ -339,9 +339,9 @@ function addReplayHooks({replayApi}: App) {
 
         replayContext.state.buffers = initialStateBuffers;
 
-        replayContext.state.buffers.source.model = sourceModel;
-        replayContext.state.buffers.input.model = inputModel;
-        replayContext.state.buffers.output.model = outputModel;
+        replayContext.state.buffers['source'].model = sourceModel;
+        replayContext.state.buffers['input'].model = inputModel;
+        replayContext.state.buffers['output'].model = outputModel;
     });
     replayApi.on('buffer.select', function(replayContext: ReplayContext, event) {
         // XXX use reducer imported from common/buffers

--- a/frontend/common/examples.ts
+++ b/frontend/common/examples.ts
@@ -28,23 +28,23 @@ function updateExamplesState(state, examples) {
        in the selector. */
     let fullCallbackUrl = url.parse(callbackUrl, true);
     delete fullCallbackUrl.search; // force url.format to rebuild the search string
-    delete fullCallbackUrl.query.source;
-    delete fullCallbackUrl.query.platform;
+    delete fullCallbackUrl.query['source'];
+    delete fullCallbackUrl.query['platform'];
 
-    fullCallbackUrl.query.language = language;
+    fullCallbackUrl.query['language'] = language;
 
     // @ts-ignore
     fullCallbackUrl = url.format(fullCallbackUrl);
 
     let fullExamplesUrl = url.parse(examplesUrl, true);
-    fullExamplesUrl.query.target = '_self';
-    fullExamplesUrl.query.tags = platform;
+    fullExamplesUrl.query['target'] = '_self';
+    fullExamplesUrl.query['tags'] = platform;
 
     /* XXX better to pass language unchanged and have the examples app drop the country code */
-    fullExamplesUrl.query.lang = language.replace(/_.*$/, '');
+    fullExamplesUrl.query['lang'] = language.replace(/_.*$/, '');
 
     // @ts-ignore
-    fullExamplesUrl.query.callback = fullCallbackUrl;
+    fullExamplesUrl.query['callback'] = fullCallbackUrl;
 
     // @ts-ignore
     fullExamplesUrl = url.format(fullExamplesUrl);

--- a/frontend/common/login.ts
+++ b/frontend/common/login.ts
@@ -21,7 +21,7 @@ export default function(bundle: Bundle) {
     bundle.defineAction(ActionTypes.LoginFeedback);
     bundle.addReducer(ActionTypes.LoginFeedback, (state: AppStore, {payload: {user, error}}): void => {
         if (!error) {
-            window.localStorage.user = JSON.stringify(user);
+            window.localStorage.setItem('user', JSON.stringify(user));
 
             state.user = user;
         }
@@ -29,7 +29,7 @@ export default function(bundle: Bundle) {
 
     bundle.defineAction(ActionTypes.LogoutFeedback);
     bundle.addReducer(ActionTypes.LogoutFeedback, (state: AppStore): void => {
-        window.localStorage.user = '';
+        window.localStorage.setItem('user', '');
 
         state.user = initialStateUser;
     });

--- a/frontend/editor/trim.ts
+++ b/frontend/editor/trim.ts
@@ -465,7 +465,7 @@ function* trimSubtitleUpload(playerUrl, subtitles) {
     const state: AppStore = yield select();
     const {baseUrl} = state.options;
     const urlParsed = url.parse(playerUrl, true);
-    const base = urlParsed.query.base; //newly generated codecast's base
+    const base = urlParsed.query['base']; //newly generated codecast's base
     const changes = {subtitles};
 
     try {

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -53,7 +53,7 @@ export interface App {
 }
 
 declare global {
-    interface Window {
+    interface Window extends WindowLocalStorage {
         store: any,
         Codecast: Codecast,
         currentPythonRunner: any,
@@ -91,7 +91,7 @@ const {store, scope, finalize, start} = link(function(bundle: Bundle) {
     bundle.include(editorBundle);
     bundle.include(statisticsBundle);
 
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env['NODE_ENV'] === 'development') {
         bundle.addEarlyReducer(function(state: AppStoreReplay, action): void {
             if (!DEBUG_IGNORE_ACTIONS_MAP[action.type]) {
                 console.log('action', action);
@@ -136,7 +136,7 @@ function restart() {
 function clearUrl() {
     const currentUrl = url.parse(document.location.href, true);
     delete currentUrl.search;
-    delete currentUrl.query.source;
+    delete currentUrl.query['source'];
 
     window.history.replaceState(null, document.title, url.format(currentUrl));
 }
@@ -237,7 +237,7 @@ Codecast.start = function(options) {
 function autoLogin() {
     let user = null;
     try {
-        user = JSON.parse(window.localStorage.user || 'null');
+        user = JSON.parse(window.localStorage.getItem('user') || 'null');
     } catch (ex) {
         return;
     }

--- a/frontend/lang/LanguageSelection.tsx
+++ b/frontend/lang/LanguageSelection.tsx
@@ -49,7 +49,7 @@ class _LanguageSelection extends React.PureComponent<LanguageSelectionProps> {
         const {closeMenu, dispatch} = this.props;
         closeMenu();
         try {
-            window.localStorage.language = language;
+            window.localStorage.setItem('language', language);
         } catch (ex) {
             // No local storage access.
         }

--- a/frontend/lang/index.ts
+++ b/frontend/lang/index.ts
@@ -16,8 +16,8 @@ export default function(bundle: Bundle) {
         if (navigator.language in Languages) {
             language = navigator.language;
         }
-        if (window.localStorage.language && window.localStorage.language in Languages) {
-            language = window.localStorage.language;
+        if (window.localStorage.getItem('language') && window.localStorage.getItem('language') in Languages) {
+            language = window.localStorage.getItem('language');
         }
         if (language in options && options.language in Languages) {
             language = options.language;

--- a/frontend/statistics/index.tsx
+++ b/frontend/statistics/index.tsx
@@ -68,6 +68,8 @@ function getBrowser() {
     if (isChrome) {
         return 'Chrome: (' + navigator.userAgent + ')';
     }
+
+    return null;
 }
 
 export const initialStateStatistics = {

--- a/frontend/stepper/c/heap.ts
+++ b/frontend/stepper/c/heap.ts
@@ -40,7 +40,7 @@ const getBlock = function(programState, ref) {
 
     const size = header & ~3;
     if (size === 0) {
-        return;
+        return null;
     }
 
     const free = 0 !== (header & 1);

--- a/frontend/stepper/index.ts
+++ b/frontend/stepper/index.ts
@@ -249,7 +249,7 @@ export default function(bundle: Bundle) {
  * @param stepperState The stepper state.
  * @param {string} context The context (Stepper.Progress, Stepper.Restart, Stepper.Idle).
  */
-function enrichStepperState(stepperState: StepperState, context: 'Stepper.Restart' | 'Stepper.Progress' | 'Stepper.Idle'): StepperState {
+function enrichStepperState(stepperState: StepperState, context: 'Stepper.Restart' | 'Stepper.Progress' | 'Stepper.Idle'): void {
     const {programState, controls} = stepperState;
     if (!programState) {
         return;
@@ -345,7 +345,7 @@ function getNodeRange(stepperState: typeof initialStateStepperState) {
 }
 
 function stringifyError(error) {
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env['NODE_ENV'] === 'production') {
         return error.toString();
     }
     if (error && error.stack) {
@@ -370,7 +370,7 @@ function stepperRestartReducer(state: AppStoreReplay, {payload: {stepperState}})
             stepperState = state.stepper.initialStepperState;
             stepperState.inputPos = 0;
 
-            const source = state.buffers.source.model.document.toString();
+            const source = state.buffers['source'].model.document.toString();
 
             /**
              * Add a last instruction at the end of the code so Skupt will generate a Suspension state

--- a/frontend/stepper/io/index.ts
+++ b/frontend/stepper/io/index.ts
@@ -116,7 +116,7 @@ export default function(bundle: Bundle) {
         });
 
         function syncOutputBufferReducer(state: AppStoreReplay): void {
-            state.buffers.output.model = getOutputBufferModel(state);
+            state.buffers['output'].model = getOutputBufferModel(state);
         }
 
         function* syncOutputBufferSaga(instant) {

--- a/frontend/stepper/python/analysis/components/PythonFunctionLocals.tsx
+++ b/frontend/stepper/python/analysis/components/PythonFunctionLocals.tsx
@@ -35,6 +35,8 @@ export const PythonFunctionLocals = (props: PythonFunctionLocalsProps): JSX.Elem
                 </li>
             );
         }
+
+        return null;
     });
 
     return (

--- a/frontend/stepper/python/index.ts
+++ b/frontend/stepper/python/index.ts
@@ -104,7 +104,7 @@ export default function(bundle: Bundle) {
 
         stepperApi.onInit(function(stepperState: StepperState, state: AppStore) {
             const {platform} = state.options;
-            const source = state.buffers.source.model.document.toString();
+            const source = state.buffers['source'].model.document.toString();
 
             if (platform === 'python') {
                 const context = {

--- a/frontend/subtitles/options.ts
+++ b/frontend/subtitles/options.ts
@@ -1,7 +1,7 @@
 export function getPersistentOptions() {
     let opts;
     try {
-        opts = JSON.parse(window.localStorage.subtitles);
+        opts = JSON.parse(window.localStorage.getItem('subtitles'));
     } catch (ex) {
         // nothing
     }
@@ -16,5 +16,5 @@ export function setPersistentOption(key, value) {
     const opts = getPersistentOptions();
     opts[key] = value;
 
-    window.localStorage.subtitles = JSON.stringify(opts);
+    window.localStorage.setItem('subtitles', JSON.stringify(opts));
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "outDir": "./build/",
     "sourceMap": true,
-    //"noImplicitAny": true,
     "module": "commonjs",
     "target": "ES6",
 
@@ -15,8 +14,6 @@
 
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "noPropertyAccessFromIndexSignature": false, // temporirly disabled, should be enabled (only 25 errors, easily fixable)
-    "noImplicitReturns": false, // temporirly disabled, should be enabled (only 5 errors, easily fixable)
     /// noUnusedLocals and noUnusedParameters are too restrictive (no way to add exceptions) so they should be checked by the eslint
 
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,20 @@
     //"noImplicitAny": true,
     "module": "commonjs",
     "target": "ES6",
-    //"strict": true,
+
+    "strict": true, // enable all strict rules, unless they are explicitely disabled (below). there should not be any of such exceptions.
+    "noImplicitAny": false, // temporirly disabled, should fix code and remove this line
+    "noImplicitThis": false, // temporirly disabled, should fix code and remove this line
+    "strictFunctionTypes": false, // temporirly disabled, should fix code and remove this line
+    "strictNullChecks": false, // temporirly disabled, should fix code and remove this line
+    "strictPropertyInitialization": false, // temporirly disabled, should fix code and remove this line
+
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false, // temporirly disabled, should be enabled (only 25 errors, easily fixable)
+    "noImplicitReturns": false, // temporirly disabled, should be enabled (only 5 errors, easily fixable)
+    /// noUnusedLocals and noUnusedParameters are too restrictive (no way to add exceptions) so they should be checked by the eslint
+
     "esModuleInterop": true,
     //"skipLibCheck": true,
     //"forceConsistentCasingInFileNames": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
 
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
     /// noUnusedLocals and noUnusedParameters are too restrictive (no way to add exceptions) so they should be checked by the eslint
 
     "esModuleInterop": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,7 +148,11 @@ module.exports = (env, argv) => {
                 Buffer: ['buffer', 'Buffer'],
                 process: ['process']
             }),
-            new ForkTsCheckerWebpackPlugin(),
+            new ForkTsCheckerWebpackPlugin({
+                typescript: {
+                    memoryLimit: 4096,
+                }
+            }),
             // new BundleAnalyzerPlugin(),
         ],
         // Note : splitChunks breaks the audio recording.


### PR DESCRIPTION
Enable typescript strictness ... but disabling some (almost all 😁) rules. The goal is to try to re-enable them one by one in the near future (some requires many changes). 

Also add linter rules embedded in the TS compiler itself.... but also disable some for now.

@SebastienTainon , if you have time, you could already fix in this PR the "noImplicitReturns" and "noPropertyAccessFromIndexSignature" rules which were not triggering many issues (and quite easy to fix). 