### PR TITLE
Integrate player to be able to replay recordings

### DIFF
--- a/backend/offline.js
+++ b/backend/offline.js
@@ -11,11 +11,11 @@ export default function (app, config, store) {
     app.use('/offline.zip', express.static(path.join(config.rootDir, 'offline.zip')));
 
     app.get('/offline', function (req, res) {
-        const baseUrl = req.query.base;
+        const baseUrl = req.query.recording;
 
         const manifestUrl = editURL(config.baseUrl, function (obj) {
             obj.pathname = urlJoin(obj.pathname, 'offline/manifest');
-            obj.query.base = baseUrl;
+            obj.query.recording = baseUrl;
         });
 
         const builderUrl = editURL(config.builderUrl, function (obj) {
@@ -48,7 +48,7 @@ export default function (app, config, store) {
                     to: {file: urlJoin(ownPath, 'index.html')},
                 },
                 {
-                    from: {url: `${query.base}.mp3`},
+                    from: {url: `${query.recording}.mp3`},
                     to: {file: urlJoin(ownPath, 'audio.mp3')},
                 }
             ]
@@ -68,7 +68,7 @@ export default function (app, config, store) {
             const options = buildCommonOptions('player', query);
             options.audioUrl = urlJoin(pathReverse(sharedPath), ownPath, "audio.mp3");
 
-            request(`${query.base}.json`, function (err, response, body) {
+            request(`${query.recording}.json`, function (err, response, body) {
                 if (err) {
                     return res.status(400).send(err.toString());
                 }

--- a/backend/options.js
+++ b/backend/options.js
@@ -75,7 +75,7 @@ export function buildOptions(config, req, start, callback) {
         options.examplesUrl = config.examplesUrl;
     }
     if (/editor|player/.test(start)) {
-        options.baseDataUrl = req.query.base;
+        options.baseDataUrl = req.query.recording;
         const {s3Bucket: bucket, uploadPath: folder, id: codecast} = parseCodecastUrl(options.baseDataUrl);
         options.codecastData = {bucket, folder, codecast};
     }
@@ -83,6 +83,10 @@ export function buildOptions(config, req, start, callback) {
         options.isStatisticsReady = !!config.database;
     }
     if (/recorder|editor|statistics|task/.test(start)) {
+        if (req.query.recording) {
+            options.baseDataUrl = req.query.recording;
+        }
+
         return config.optionsHook(req, options, callback);
     } else {
         return callback(null, options);

--- a/backend/server.js
+++ b/backend/server.js
@@ -197,7 +197,7 @@ function addBackendRoutes(app, config, store) {
                     upload.getMp3UploadForm(s3client, s3Bucket, uploadPath, function (err, audio) {
                         if (err) return res.json({error: err.toString()});
                         const baseUrl = `https://${s3Bucket}.s3.amazonaws.com/${uploadPath}`;
-                        const player_url = `${config.playerUrl}?base=${encodeURIComponent(baseUrl)}`;
+                        const player_url = `${config.playerUrl}?recording=${encodeURIComponent(baseUrl)}`;
                         res.json({player_url, events, audio});
                     });
                 });
@@ -455,7 +455,7 @@ fs.readFile('config.json', 'utf8', function (err, data) {
     console.log(`running in ${config.isDevelopment ? 'development' : 'production'} mode`);
 
     if (!config.playerUrl) {
-        config.playerUrl = `${config.baseUrl}/player`;
+        config.playerUrl = `${config.baseUrl}/task`;
     }
 
     const workerStore = startWorker(config);

--- a/frontend/common/Menu.tsx
+++ b/frontend/common/Menu.tsx
@@ -22,7 +22,7 @@ function mapStateToProps(state: AppStore): MenuStateToProps {
 
     let offlineDownloadUrl = null;
     if (!isLocalMode() && baseDataUrl) {
-        offlineDownloadUrl = baseUrl + '/offline?base=' + encodeURIComponent(baseDataUrl);
+        offlineDownloadUrl = baseUrl + '/offline?recording=' + encodeURIComponent(baseDataUrl);
     }
 
     return {

--- a/frontend/editor/index.tsx
+++ b/frontend/editor/index.tsx
@@ -52,7 +52,7 @@ export default function(bundle: Bundle) {
         state.editor = initialStateEditor;
         state.editor.base = baseDataUrl;
         state.editor.dataUrl = baseDataUrl;
-        state.editor.playerUrl = `${baseUrl}/player?base=${encodeURIComponent(baseDataUrl)}`;
+        state.editor.playerUrl = `${baseUrl}/task?recording=${encodeURIComponent(baseDataUrl)}`;
         state.editor.canSave = userHasGrant(state.user, baseDataUrl);
     });
 

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -60,7 +60,6 @@ declare global {
         currentPythonRunner: any,
         currentPythonContext: any,
         languageStrings: any,
-        quickAlgoInterface: any,
         __REDUX_DEVTOOLS_EXTENSION__: any,
         __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: any,
         quickAlgoContext: (display: boolean, infos: any) => QuickAlgoContext,

--- a/frontend/lang/en-US.js
+++ b/frontend/lang/en-US.js
@@ -37,6 +37,7 @@ module.exports = {
     UPLOADING_URL_AUDIO_MP3: "URL audio (mp3)",
     UPLOADING_URL_AUDIO_WAV: "URL audio (wav)",
     PLAYBACK_LINK: "Playback link:",
+    PLAYER_PREPARING: "Preparing playback",
     IOPANE_MODE: "Input/output mechanism:",
     IOPANE_MODE_SPLIT: "Split input/output",
     IOPANE_MODE_INTERACTIVE: "Interactive terminal",

--- a/frontend/lang/fr-FR.js
+++ b/frontend/lang/fr-FR.js
@@ -37,6 +37,7 @@ module.exports = {
     UPLOADING_URL_AUDIO_MP3: "URL audio (mp3)",
     UPLOADING_URL_AUDIO_WAV: "URL audio (wav)",
     PLAYBACK_LINK: "Lien pour la lecture :",
+    PLAYER_PREPARING: "Chargement de l'enregistrement en cours",
     IOPANE_MODE: "Mécanisme d'entrée/sortie :",
     IOPANE_MODE_SPLIT: "Entrée/sortie séparés",
     IOPANE_MODE_INTERACTIVE: "Terminal interactif",

--- a/frontend/player/sagas.ts
+++ b/frontend/player/sagas.ts
@@ -105,10 +105,17 @@ function* playerPrepare(app: App, action) {
         payload: platform
     });
 
+    const context = state.task.context;
+    context.display = false;
+
     const replayState = {
         options: {
             platform
-        }
+        },
+        task: {
+            context,
+            state: {...state.task.context.getCurrentState()},
+        },
     };
 
     if (data.options) {
@@ -129,6 +136,8 @@ function* playerPrepare(app: App, action) {
 
     try {
         yield call(computeInstants, replayApi, replayContext);
+
+        context.display = true;
 
         /* The duration of the recording is the timestamp of the last event. */
         const instants = replayContext.instants;

--- a/frontend/recorder/sagas.ts
+++ b/frontend/recorder/sagas.ts
@@ -7,6 +7,7 @@ import AudioWorker from '../audio_worker/index.worker';
 import {ActionTypes} from "./actionTypes";
 import {ActionTypes as CommonActionTypes} from '../common/actionTypes';
 import {ActionTypes as PlayerActionTypes} from '../player/actionTypes';
+import {ActionTypes as StepperActionTypes} from '../stepper/actionTypes';
 import {getPlayerState} from "../player/selectors";
 import {getRecorderState} from "./selectors";
 import {AppStore} from "../store";
@@ -14,6 +15,7 @@ import {RecorderStatus} from "./store";
 import {ReplayContext} from "../player/sagas";
 import {App} from "../index";
 import {Screen} from "../common/screens";
+import {StepperStatus} from "../stepper";
 
 export default function(bundle, deps) {
     bundle.use('recordApi');
@@ -164,6 +166,10 @@ export default function(bundle, deps) {
                 console.log('not ready', recorder);
 
                 return;
+            }
+
+            if (state.stepper && state.stepper.status !== StepperStatus.Clear) {
+                yield put({type: StepperActionTypes.StepperExit});
             }
 
             // Signal that the recorder is starting.

--- a/frontend/stepper/actionTypes.ts
+++ b/frontend/stepper/actionTypes.ts
@@ -9,7 +9,7 @@ export enum ActionTypes {
     StepperProgress = 'Stepper.Progress',
     StepperIdle = 'Stepper.Idle',
     StepperExit = 'Stepper.Exit',
-    StepperError = 'Stepper.Error',
+    StepperInterrupting = 'Stepper.Interrupting',
     StepperInterrupt = 'Stepper.Interrupt',
     StepperInterrupted = 'Stepper.Interrupted',
     StepperUndo = 'Stepper.Undo',

--- a/frontend/stepper/actionTypes.ts
+++ b/frontend/stepper/actionTypes.ts
@@ -9,6 +9,7 @@ export enum ActionTypes {
     StepperProgress = 'Stepper.Progress',
     StepperIdle = 'Stepper.Idle',
     StepperExit = 'Stepper.Exit',
+    StepperError = 'Stepper.Error',
     StepperInterrupt = 'Stepper.Interrupt',
     StepperInterrupted = 'Stepper.Interrupted',
     StepperUndo = 'Stepper.Undo',

--- a/frontend/stepper/api.ts
+++ b/frontend/stepper/api.ts
@@ -51,7 +51,7 @@ function onInit(callback: (stepperState: StepperState, state: AppStore) => void)
 }
 
 /* Build a stepper state from the given init data. */
-export async function buildState(state: AppStoreReplay): Promise<StepperState> {
+export async function buildState(state: AppStoreReplay, replay: boolean = false): Promise<StepperState> {
     const {platform} = state.options;
 
     /*
@@ -63,7 +63,7 @@ export async function buildState(state: AppStoreReplay): Promise<StepperState> {
         platform
     } as StepperState;
     for (let callback of initCallbacks) {
-        callback(curStepperState, state);
+        callback(curStepperState, state, replay);
     }
 
     // TODO: Make something so that the initCallbacks doesn't obscure the creation of stepperState.

--- a/frontend/stepper/index.ts
+++ b/frontend/stepper/index.ts
@@ -525,7 +525,7 @@ function stepperConfigureReducer(state: AppStore, action): void {
     return state.stepper.options = options;
 }
 
-function stepperSpeedChangedReducer(state: AppStore, {payload: {speed}}): void {
+function stepperSpeedChangedReducer(state: AppStoreReplay, {payload: {speed}}): void {
     return state.stepper.speed = speed;
 }
 
@@ -1050,6 +1050,17 @@ function postLink(app: App) {
         const update = event[3];
 
         stepperViewControlsChangedReducer(replayContext.state, {key, update});
+    });
+
+    recordApi.on(ActionTypes.StepperSpeedChanged, function* (addEvent, action) {
+        const {payload: {speed}} = action;
+
+        yield call(addEvent, 'stepper.speed.changed', speed);
+    });
+    replayApi.on('stepper.speed.changed', function(replayContext: ReplayContext, event) {
+        const speed = event[2];
+
+        stepperSpeedChangedReducer(replayContext.state, {payload: {speed}});
     });
 
     stepperApi.onInit(function(stepperState: StepperState, state: AppStore) {

--- a/frontend/stepper/index.ts
+++ b/frontend/stepper/index.ts
@@ -131,7 +131,8 @@ const initialStateStepperState = {
         memorySize: 0x10000,
         stackSize: 4096
     },
-    isFinished: false // Only used for python
+    isFinished: false, // Only used for python
+    contextState: {} as any,
 };
 
 export type StepperState = typeof initialStateStepperState;
@@ -459,6 +460,7 @@ function stepperProgressReducer(state: AppStoreReplay, {payload: {stepperContext
         }
     }
 
+    state.task.state = {...state.task.context.getCurrentState()};
     state.stepper.currentStepperState = stepperContext.state;
     if (state.compile.status === CompileStatus.Error) {
         state.stepper.currentStepperState.isFinished = false;

--- a/frontend/stepper/index.ts
+++ b/frontend/stepper/index.ts
@@ -204,8 +204,8 @@ export default function(bundle: Bundle) {
     bundle.defineAction(ActionTypes.StepperExit);
     bundle.addReducer(ActionTypes.StepperExit, stepperExitReducer);
 
-    bundle.defineAction(ActionTypes.StepperError);
-    bundle.addReducer(ActionTypes.StepperError, stepperInterruptReducer);
+    bundle.defineAction(ActionTypes.StepperInterrupting);
+    bundle.addReducer(ActionTypes.StepperInterrupting, stepperInterruptReducer);
 
     // Sent when the user interrupts the stepper.
     bundle.defineAction(ActionTypes.StepperInterrupt);
@@ -490,7 +490,7 @@ function stepperExitReducer(state: AppStoreReplay): void {
 
 function stepperInterruptReducer(state: AppStore): void {
     // Cannot interrupt while idle.
-    if (state.stepper.status != StepperStatus.Idle) {
+    if (state.stepper.status !== StepperStatus.Idle) {
         state.stepper.interrupting = true;
     }
 }

--- a/frontend/stepper/index.ts
+++ b/frontend/stepper/index.ts
@@ -529,7 +529,7 @@ function stepperSpeedChangedReducer(state: AppStoreReplay, {payload: {speed}}): 
     return state.stepper.speed = speed;
 }
 
-function stepperControlsChangedReducer(state: AppStore, {payload: {controls}}): void {
+function stepperControlsChangedReducer(state: AppStoreReplay, {payload: {controls}}): void {
     return state.stepper.controls = controls;
 }
 
@@ -1061,6 +1061,17 @@ function postLink(app: App) {
         const speed = event[2];
 
         stepperSpeedChangedReducer(replayContext.state, {payload: {speed}});
+    });
+
+    recordApi.on(ActionTypes.StepperControlsChanged, function* (addEvent, action) {
+        const {payload: {controls}} = action;
+
+        yield call(addEvent, 'stepper.controls.changed', controls);
+    });
+    replayApi.on('stepper.controls.changed', function(replayContext: ReplayContext, event) {
+        const controls = event[2];
+
+        stepperControlsChangedReducer(replayContext.state, {payload: {controls}});
     });
 
     stepperApi.onInit(function(stepperState: StepperState, state: AppStore) {

--- a/frontend/stepper/index.ts
+++ b/frontend/stepper/index.ts
@@ -204,6 +204,9 @@ export default function(bundle: Bundle) {
     bundle.defineAction(ActionTypes.StepperExit);
     bundle.addReducer(ActionTypes.StepperExit, stepperExitReducer);
 
+    bundle.defineAction(ActionTypes.StepperError);
+    bundle.addReducer(ActionTypes.StepperError, stepperInterruptReducer);
+
     // Sent when the user interrupts the stepper.
     bundle.defineAction(ActionTypes.StepperInterrupt);
     bundle.addReducer(ActionTypes.StepperInterrupt, stepperInterruptReducer);
@@ -850,7 +853,7 @@ function postLink(app: App) {
         yield call(addEvent, 'stepper.restart');
     });
     replayApi.on('stepper.restart', async function(replayContext: ReplayContext) {
-        const stepperState = await buildState(replayContext.state);
+        const stepperState = await buildState(replayContext.state, true);
 
         replayContext.state = produce(replayContext.state, (draft: AppStoreReplay) => {
             stepperRestartReducer(draft, {payload: {stepperState}});

--- a/frontend/stepper/python/index.ts
+++ b/frontend/stepper/python/index.ts
@@ -104,7 +104,7 @@ export default function(bundle: Bundle) {
             stackViewPathToggleReducer(replayContext.state, action);
         });
 
-        stepperApi.onInit(function(stepperState: StepperState, state: AppStore) {
+        stepperApi.onInit(function(stepperState: StepperState, state: AppStore, replay: boolean = false) {
             const {platform} = state.options;
             const source = state.buffers['source'].model.document.toString();
 
@@ -112,7 +112,15 @@ export default function(bundle: Bundle) {
                 const context = state.task.context;
                 context.reset();
                 context.onError = (diagnostics) => {
+                    if (replay) {
+                        return;
+                    }
+
                     const response = {diagnostics};
+
+                    pythonInterpreterChannel.put({
+                        type: CompileActionTypes.StepperError,
+                    });
 
                     pythonInterpreterChannel.put({
                         type: CompileActionTypes.CompileFailed,

--- a/frontend/stepper/python/index.ts
+++ b/frontend/stepper/python/index.ts
@@ -5,6 +5,7 @@ import PythonInterpreter from "./python_interpreter";
 import {ActionTypes} from './actionTypes';
 import {ActionTypes as CompileActionTypes} from '../actionTypes';
 import {ActionTypes as IoActionTypes} from '../io/actionTypes';
+import {ActionTypes as TaskActionTypes} from '../../task/actionTypes';
 import {AppStore, AppStoreReplay} from "../../store";
 import {ReplayContext} from "../../player/sagas";
 import {StepperState} from "../index";
@@ -116,15 +117,28 @@ export default function(bundle: Bundle) {
                         return;
                     }
 
-                    const response = {diagnostics};
-
                     pythonInterpreterChannel.put({
-                        type: CompileActionTypes.StepperError,
+                        type: CompileActionTypes.StepperInterrupting,
                     });
 
+                    const response = {diagnostics};
                     pythonInterpreterChannel.put({
                         type: CompileActionTypes.CompileFailed,
                         response
+                    });
+                };
+                context.onSuccess = (message) => {
+                    if (replay) {
+                        return;
+                    }
+
+                    pythonInterpreterChannel.put({
+                        type: CompileActionTypes.StepperInterrupting,
+                    });
+
+                    pythonInterpreterChannel.put({
+                        type: TaskActionTypes.TaskSuccess,
+                        payload: {message},
                     });
                 };
                 context.onInput = () => {

--- a/frontend/stepper/python/python_interpreter.ts
+++ b/frontend/stepper/python/python_interpreter.ts
@@ -35,6 +35,7 @@ export default function(context) {
     this._synchronizingAnalysis = false;
     this.onInput = context.onInput;
     this.onError = context.onError;
+    this.onSuccess = context.onSuccess;
 
     var that = this;
 
@@ -664,16 +665,11 @@ export default function(context) {
 
         // Transform message depending on whether we successfully
         if (this.context.success) {
-            message = '<span style="color:green;font-weight:bold">' + message + '</span>';
+            this.onSuccess(message);
         } else {
             message = this.context.messagePrefixFailure + message;
+            this.onError(message);
         }
-
-        if (window.quickAlgoInterface) {
-            window.quickAlgoInterface.setPlayPause(false);
-        }
-
-        this.onError(message);
 
         if (typeof callback === 'function') {
             callback();

--- a/frontend/stepper/views/StepperControls.tsx
+++ b/frontend/stepper/views/StepperControls.tsx
@@ -328,14 +328,13 @@ class _StepperControls extends React.PureComponent<StepperControlsProps> {
     onRedo = () => this.props.dispatch({type: ActionTypes.StepperRedo, payload: {}});
     onCompile = () => this.props.dispatch({type: ActionTypes.Compile, payload: {}});
     onStepByStep = async () => {
-        if (this.props.controlsType !== StepperControlsType.StepByStep) {
-            await this.props.dispatch({type: ActionTypes.StepperControlsChanged, payload: {controls: StepperControlsType.StepByStep}});
-        }
-
         if (!await this.compileIfNecessary()) {
             return;
         }
 
+        if (this.props.controlsType !== StepperControlsType.StepByStep) {
+            await this.props.dispatch({type: ActionTypes.StepperControlsChanged, payload: {controls: StepperControlsType.StepByStep}});
+        }
         if (this.props.canStep) {
             this.props.dispatch({type: ActionTypes.StepperStep, payload: {mode: StepperStepMode.Into}});
         } else {
@@ -346,8 +345,12 @@ class _StepperControls extends React.PureComponent<StepperControlsProps> {
         if (!await this.compileIfNecessary()) {
             return;
         }
-        await this.props.dispatch({type: ActionTypes.StepperInterrupt, payload: {}});
-        await this.props.dispatch({type: ActionTypes.StepperControlsChanged, payload: {controls: StepperControlsType.Normal}});
+        if (this.props.controlsType !== StepperControlsType.Normal) {
+            await this.props.dispatch({type: ActionTypes.StepperControlsChanged, payload: {controls: StepperControlsType.Normal}});
+        }
+        if (!this.props.canStep) {
+            await this.props.dispatch({type: ActionTypes.StepperInterrupt, payload: {}});
+        }
         setTimeout(() => {
             this.props.dispatch({type: ActionTypes.StepperStep, payload: {mode: StepperStepMode.Run}});
         }, 250);

--- a/frontend/stepper/views/StepperControls.tsx
+++ b/frontend/stepper/views/StepperControls.tsx
@@ -332,12 +332,11 @@ class _StepperControls extends React.PureComponent<StepperControlsProps> {
             await this.props.dispatch({type: ActionTypes.StepperControlsChanged, payload: {controls: StepperControlsType.StepByStep}});
         }
 
-        const compile = this.props.canCompile;
         if (!await this.compileIfNecessary()) {
             return;
         }
 
-        if (!compile && this.props.canStep) {
+        if (this.props.canStep) {
             this.props.dispatch({type: ActionTypes.StepperStep, payload: {mode: StepperStepMode.Into}});
         } else {
             await this.props.dispatch({type: ActionTypes.StepperInterrupt, payload: {}});

--- a/frontend/store.ts
+++ b/frontend/store.ts
@@ -64,6 +64,7 @@ export interface AppStoreReplay {
     buffers: typeof initialStateBuffers,
     stepper: Stepper,
     compile: typeof initialStateCompile,
+    task: TaskState,
 
     options: CodecastOptions,
 

--- a/frontend/task/MenuTask.tsx
+++ b/frontend/task/MenuTask.tsx
@@ -15,20 +15,22 @@ interface MenuTaskStateToProps {
     platform: string,
     offlineDownloadUrl: string,
     recordingEnabled: boolean,
+    playerEnabled: boolean,
 }
 
 function mapStateToProps(state: AppStore): MenuTaskStateToProps {
     const {baseUrl, baseDataUrl, platform, canChangePlatform} = state.options;
     const getMessage = state.getMessage;
     const recordingEnabled = state.task.recordingEnabled;
+    const playerEnabled = !!state.options.baseDataUrl;
 
     let offlineDownloadUrl = null;
     if (!isLocalMode() && baseDataUrl) {
-        offlineDownloadUrl = baseUrl + '/offline?base=' + encodeURIComponent(baseDataUrl);
+        offlineDownloadUrl = baseUrl + '/offline?recording=' + encodeURIComponent(baseDataUrl);
     }
 
     return {
-        getMessage, platform, canChangePlatform, offlineDownloadUrl, recordingEnabled,
+        getMessage, platform, canChangePlatform, offlineDownloadUrl, recordingEnabled, playerEnabled,
     };
 }
 
@@ -52,7 +54,7 @@ class _MenuTask extends React.PureComponent<MenuTaskProps, MenuTaskState> {
     };
 
     render() {
-        const {getMessage, platform, canChangePlatform, offlineDownloadUrl} = this.props;
+        const {getMessage, platform, canChangePlatform, offlineDownloadUrl, playerEnabled} = this.props;
         const {settingsOpen} = this.state;
 
         return (
@@ -67,10 +69,10 @@ class _MenuTask extends React.PureComponent<MenuTaskProps, MenuTaskState> {
                         <Icon icon="globe"/>
                         <span>{getMessage('MENU_LANGUAGE')}</span>
                     </div>
-                    <div className="menu-item" onClick={this.toggleRecording}>
+                    {!playerEnabled && <div className="menu-item" onClick={this.toggleRecording}>
                         <Icon icon="record" color="#ff001f"/>
                         <span>{getMessage('MENU_RECORDER')}</span>
-                    </div>
+                    </div>}
                     <Dialog icon='menu' title={getMessage('SETTINGS_MENU_TITLE')} isOpen={settingsOpen} onClose={this.closeSettings}>
                         <div className='bp3-dialog-body'>
                             <div style={{marginBottom: '10px'}}>

--- a/frontend/task/PlayerControlsTask.tsx
+++ b/frontend/task/PlayerControlsTask.tsx
@@ -97,7 +97,7 @@ class _PlayerControlsTask extends React.PureComponent<PlayerControlsTaskProps> {
                             max={1}
                             labelRenderer={false}
                             stepSize={0.01}
-                            disabled={!isReady}
+                            disabled={!isReady || isMuted}
                         />
                     </div>
                 </div>

--- a/frontend/task/PlayerControlsTask.tsx
+++ b/frontend/task/PlayerControlsTask.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import {Button, ButtonGroup, Icon, Slider} from "@blueprintjs/core";
+import {formatTime} from "../common/utils";
+import {ActionTypes} from "../player/actionTypes";
+import {connect} from "react-redux";
+import {StepperControls} from "../stepper/views/StepperControls";
+import {Menu} from "../common/Menu";
+import {AppStore} from "../store";
+
+interface PlayerControlsTaskStateToProps {
+    isReady: boolean,
+    isPlaying: boolean,
+    isAtEnd: boolean,
+    audioTime: number,
+    duration: number,
+    volume: any,
+    isMuted: boolean,
+    getMessage: Function
+}
+
+function mapStateToProps(state: AppStore): PlayerControlsTaskStateToProps {
+    const getMessage = state.getMessage;
+    const player = state.player;
+    const isReady = player.isReady;
+    const isPlaying = player.isPlaying;
+    const currentInstant = player.current;
+    const isAtEnd = currentInstant && currentInstant.isEnd;
+    const audioTime = player.audioTime;
+    const duration = player.duration;
+    const volume = player.volume;
+    const isMuted = player.isMuted;
+
+    return {getMessage, isReady, isPlaying, isAtEnd, audioTime, duration, volume, isMuted};
+}
+
+interface PlayerControlsTaskDispatchToProps {
+    dispatch: Function
+}
+
+interface PlayerControlsTaskProps extends PlayerControlsTaskStateToProps, PlayerControlsTaskDispatchToProps {
+
+}
+
+class _PlayerControlsTask extends React.PureComponent<PlayerControlsTaskProps> {
+    render() {
+        const {isReady, isPlaying, isAtEnd, audioTime, duration, volume, isMuted, getMessage} = this.props;
+        const showStartPlayback = !isPlaying;
+        const canStartPlayback = isReady && !isPlaying;
+        const showPausePlayback = isPlaying;
+        const canPausePlayback = isPlaying;
+
+        return (
+            <div className="task-recorder-controls">
+                <div className="controls-recorder">
+                    <ButtonGroup>
+                        {showStartPlayback &&
+                            <Button
+                              onClick={this.onStartPlayback}
+                              disabled={!canStartPlayback}
+                              title={getMessage('START_PLAYBACK')}
+                              icon={isAtEnd ? 'repeat' : 'play'}
+                            />
+                        }
+                        {showPausePlayback &&
+                            <Button
+                              onClick={this.onPausePlayback}
+                              disabled={!canPausePlayback}
+                              title={getMessage('PAUSE_PLAYBACK')}
+                              icon='pause'
+                            />
+                        }
+                    </ButtonGroup>
+                </div>
+                <div className="controls-recorder controls-mute">
+                    <div className="player-controls-mute">
+                        {isMuted ?
+                            <Button
+                                title={getMessage('SOUND_OFF')}
+                                onClick={(isReady) ? this.handleMuteChange.bind(this, false) : undefined}
+                                icon='volume-off'
+                                disabled={!isReady}
+                            />
+                            :
+                            <Button
+                                title={getMessage('SOUND_ON')}
+                                onClick={(isReady) ? this.handleMuteChange.bind(this, true) : undefined}
+                                icon='volume-up'
+                                disabled={!isReady}
+                            />
+                        }
+                    </div>
+                    <div className="player-controls-volume">
+                        <Slider
+                            value={volume}
+                            onChange={this.handleVolumeChange}
+                            min={0}
+                            max={1}
+                            labelRenderer={false}
+                            stepSize={0.01}
+                            disabled={!isReady}
+                        />
+                    </div>
+                </div>
+                <div className="controls-time">
+                    <span style={{marginLeft: '4px'}}>
+                        {formatTime(audioTime)}
+                    </span>
+                </div>
+                <div className="player-slider-container">
+                    {!Number.isNaN(duration) &&
+                        <Slider
+                          value={audioTime}
+                          onChange={this.onSeek}
+                          min={0}
+                          max={duration}
+                          stepSize={100}
+                          labelStepSize={duration}
+                          labelRenderer={formatTime}
+                        />
+                    }
+                </div>
+                <div className="controls-time time-duration">
+                    <span style={{marginLeft: '4px'}}>
+                        {formatTime(duration)}
+                    </span>
+                </div>
+            </div>
+        );
+    };
+
+    onStartPlayback = () => {
+        this.props.dispatch({type: ActionTypes.PlayerStart});
+    };
+
+    onPausePlayback = () => {
+        this.props.dispatch({type: ActionTypes.PlayerPause});
+    };
+
+    onSeek = (audioTime) => {
+        this.props.dispatch({type: ActionTypes.PlayerSeek, payload: {audioTime}});
+    };
+
+    handleVolumeChange = (volume) => {
+        this.props.dispatch({type: ActionTypes.PlayerVolumeChanged, payload: {volume}});
+    };
+
+    handleMuteChange = (isMuted) => {
+        this.props.dispatch({type: ActionTypes.PlayerMutedChanged, payload: {isMuted}});
+    };
+}
+
+export const PlayerControlsTask = connect(mapStateToProps)(_PlayerControlsTask);

--- a/frontend/task/RecorderControlsTask.tsx
+++ b/frontend/task/RecorderControlsTask.tsx
@@ -124,20 +124,20 @@ class _RecorderControlsTask extends React.PureComponent<RecorderControlsTaskProp
                     </span>
                 </div>
                 {isPlayback &&
-                  <div className="player-slider-container">
-                    <Slider
-                      value={position}
-                      onChange={this.onSeek}
-                      stepSize={100}
-                      labelStepSize={30000}
-                      min={0}
-                      max={duration}
-                      labelRenderer={formatTime}
-                    />
-                  </div>
+                    <div className="player-slider-container">
+                      <Slider
+                        value={position}
+                        onChange={this.onSeek}
+                        stepSize={100}
+                        labelStepSize={30000}
+                        min={0}
+                        max={duration}
+                        labelRenderer={formatTime}
+                      />
+                    </div>
                 }
                 {isPlayback &&
-                    <div className="controls-time">
+                    <div className="controls-time time-duration">
                         <span style={{marginLeft: '4px'}}>
                             {isPlayback && formatTime(duration)}
                         </span>

--- a/frontend/task/TaskApp.tsx
+++ b/frontend/task/TaskApp.tsx
@@ -38,6 +38,8 @@ interface TaskAppStateToProps {
     playerError: PlayerError,
     getMessage: Function,
     options: CodecastOptions,
+    taskSuccess: boolean,
+    taskSuccessMessage: string,
 }
 
 function mapStateToProps(state: AppStore): TaskAppStateToProps {
@@ -53,6 +55,8 @@ function mapStateToProps(state: AppStore): TaskAppStateToProps {
     const error = currentStepperState && currentStepperState.error;
     const recordingEnabled = state.task.recordingEnabled;
     const playerEnabled = !!state.options.baseDataUrl;
+    const taskSuccess = state.task.success;
+    const taskSuccessMessage = state.task.successMessage;
 
     /* TODO: make number of visible rows in source editor configurable. */
     const sourceRowHeight = Math.ceil(16 * 25); // 12*25 for /next
@@ -88,7 +92,7 @@ function mapStateToProps(state: AppStore): TaskAppStateToProps {
         sourceMode, showStack, arduinoEnabled, showViews, showIO, windowHeight,
         currentStepperState, fullScreenActive, diagnostics, recordingEnabled,
         preventInput, isPlayerReady, playerProgress, playerError, playerEnabled,
-        options,
+        options, taskSuccess, taskSuccessMessage,
     };
 }
 
@@ -114,6 +118,7 @@ class _TaskApp extends React.PureComponent<TaskAppProps, TaskAppState> {
             diagnostics, recordingEnabled,
             playerProgress, isPlayerReady,
             playerEnabled, getMessage,
+            taskSuccess, taskSuccessMessage,
         } = this.props;
 
         const hasError = !!(error || diagnostics);
@@ -189,6 +194,17 @@ class _TaskApp extends React.PureComponent<TaskAppProps, TaskAppState> {
                         <ProgressBar value={playerProgress} intent={Intent.SUCCESS}/>
                     </div>
                 </Dialog>
+
+                <Dialog isOpen={taskSuccess} className="simple-dialog" onClose={this.closeTaskSuccess}>
+                    <p className="simple-dialog-success">{taskSuccessMessage}</p>
+
+                    <div className="simple-dialog-buttons">
+                        <button className="simple-dialog-button" onClick={this.closeTaskSuccess}>
+                            <Icon icon="small-tick" iconSize={24}/>
+                            <span>Ok</span>
+                        </button>
+                    </div>
+                </Dialog>
             </Container>
         );
     };
@@ -211,6 +227,10 @@ class _TaskApp extends React.PureComponent<TaskAppProps, TaskAppState> {
 
     _onClearDiagnostics = () => {
         this.props.dispatch({type: StepperActionTypes.CompileClearDiagnostics});
+    };
+
+    closeTaskSuccess = () => {
+        this.props.dispatch({type: ActionTypes.TaskSuccessClear});
     };
 }
 

--- a/frontend/task/actionTypes.ts
+++ b/frontend/task/actionTypes.ts
@@ -1,5 +1,7 @@
 export enum ActionTypes {
   TaskLoad = 'Task.Load',
+  TaskSuccess = 'Task.Success',
+  TaskSuccessClear = 'Task.Success.Clear',
   TaskUpdateContext = 'Task.UpdateContext',
   TaskContextStateReload = 'Task.Context.State.Reload',
   TaskRecordingEnabledChange = 'Task.Recording.Enabled.Change',

--- a/frontend/task/actionTypes.ts
+++ b/frontend/task/actionTypes.ts
@@ -1,5 +1,6 @@
 export enum ActionTypes {
   TaskLoad = 'Task.Load',
   TaskUpdateContext = 'Task.UpdateContext',
+  TaskContextStateReload = 'Task.Context.State.Reload',
   TaskRecordingEnabledChange = 'Task.Recording.Enabled.Change',
 }

--- a/frontend/task/actionTypes.ts
+++ b/frontend/task/actionTypes.ts
@@ -3,6 +3,6 @@ export enum ActionTypes {
   TaskSuccess = 'Task.Success',
   TaskSuccessClear = 'Task.Success.Clear',
   TaskUpdateContext = 'Task.UpdateContext',
-  TaskContextStateReload = 'Task.Context.State.Reload',
+  TaskReset = 'Task.Reset',
   TaskRecordingEnabledChange = 'Task.Recording.Enabled.Change',
 }

--- a/frontend/task/index.ts
+++ b/frontend/task/index.ts
@@ -10,6 +10,7 @@ import {put, select, takeEvery} from "redux-saga/effects";
 import {getRecorderState} from "../recorder/selectors";
 import {App} from "../index";
 import {PlayerInstant} from "../player";
+import {clearStepper} from "../stepper";
 
 export interface QuickAlgoContext {
     display: boolean,
@@ -38,6 +39,7 @@ export interface QuickAlgoContext {
     stringsLanguage?: any,
     runner?: any,
     propagate?: Function,
+    onSuccess?: Function,
     onError?: Function,
     onInput?: Function,
     getCurrentState?: () => any,
@@ -48,6 +50,8 @@ export interface TaskState {
     recordingEnabled: boolean,
     context?: QuickAlgoContext,
     state?: any,
+    success?: boolean,
+    successMessage?: string,
 }
 
 export function quickAlgoInit() {
@@ -425,6 +429,19 @@ export default function (bundle: Bundle) {
     bundle.defineAction(ActionTypes.TaskRecordingEnabledChange);
     bundle.addReducer(ActionTypes.TaskRecordingEnabledChange, (state: AppStore, {payload: {enabled}}) => {
         state.task.recordingEnabled = enabled;
+    });
+
+    bundle.defineAction(ActionTypes.TaskSuccess);
+    bundle.addReducer(ActionTypes.TaskSuccess, (state: AppStore, {payload: {message}}) => {
+        state.task.success = true;
+        state.task.successMessage = message;
+        clearStepper(state.stepper);
+    });
+
+    bundle.defineAction(ActionTypes.TaskSuccessClear);
+    bundle.addReducer(ActionTypes.TaskSuccessClear, (state: AppStore) => {
+        state.task.success = false;
+        state.task.successMessage = null;
     });
 
     bundle.addSaga(function* () {

--- a/frontend/task/index.ts
+++ b/frontend/task/index.ts
@@ -3,14 +3,15 @@ import {extractLevelSpecific, mergeIntoArray, mergeIntoObject} from "./utils";
 import StringRotation from './fixtures/14_strings_05_rotation';
 import {ActionTypes} from "./actionTypes";
 import {Bundle} from "../linker";
-import {AppStore} from "../store";
+import {AppStore, AppStoreReplay} from "../store";
 import {ActionTypes as AppActionTypes} from "../actionTypes";
 import {ActionTypes as RecorderActionTypes} from "../recorder/actionTypes";
-import {put, select, takeEvery} from "redux-saga/effects";
+import {call, put, select, takeEvery} from "redux-saga/effects";
 import {getRecorderState} from "../recorder/selectors";
 import {App} from "../index";
 import {PlayerInstant} from "../player";
 import {clearStepper} from "../stepper";
+import {ReplayContext} from "../player/sagas";
 
 export interface QuickAlgoContext {
     display: boolean,
@@ -370,6 +371,17 @@ function taskUpdateContextReducer(state: AppStore, {payload: {context}}): void {
     state.task.context = context;
 }
 
+function taskSuccessReducer(state: AppStoreReplay, {payload: {message}}): void {
+    state.task.success = true;
+    state.task.successMessage = message;
+    clearStepper(state.stepper);
+}
+
+function taskSuccessClearReducer(state: AppStoreReplay): void {
+    state.task.success = false;
+    state.task.successMessage = null;
+}
+
 export function createContext () {
     const curLevel = 'easy';
     const subTask = StringRotation;
@@ -432,17 +444,10 @@ export default function (bundle: Bundle) {
     });
 
     bundle.defineAction(ActionTypes.TaskSuccess);
-    bundle.addReducer(ActionTypes.TaskSuccess, (state: AppStore, {payload: {message}}) => {
-        state.task.success = true;
-        state.task.successMessage = message;
-        clearStepper(state.stepper);
-    });
+    bundle.addReducer(ActionTypes.TaskSuccess, taskSuccessReducer);
 
     bundle.defineAction(ActionTypes.TaskSuccessClear);
-    bundle.addReducer(ActionTypes.TaskSuccessClear, (state: AppStore) => {
-        state.task.success = false;
-        state.task.successMessage = null;
-    });
+    bundle.addReducer(ActionTypes.TaskSuccessClear, taskSuccessClearReducer);
 
     bundle.addSaga(function* () {
         yield takeEvery(ActionTypes.TaskLoad, function* () {
@@ -458,19 +463,41 @@ export default function (bundle: Bundle) {
             }
         });
 
-        yield takeEvery(ActionTypes.TaskContextStateReload, function* (action) {
+        // @ts-ignore
+        yield takeEvery(ActionTypes.TaskReset, function* ({payload: {state: taskData}}) {
             const state = yield select();
-            // @ts-ignore
-            state.task.context.reloadState(action.payload.state);
+            state.task.success = taskData.success;
+            state.task.successMessage = taskData.successMessage;
+            if (taskData.state) {
+                state.task.context.reloadState(taskData.state);
+            }
         });
     });
 
-    bundle.defer(function({replayApi}: App) {
+    bundle.defer(function({replayApi, recordApi}: App) {
         replayApi.onReset(function* (instant: PlayerInstant) {
             const taskData = instant.state.task;
-            if (taskData && taskData.state) {
-                yield put({type: ActionTypes.TaskContextStateReload, payload: {state: taskData.state}});
+            if (taskData) {
+                yield put({type: ActionTypes.TaskReset, payload: {state: taskData}});
             }
+        });
+
+        recordApi.on(ActionTypes.TaskSuccess, function* (addEvent, action) {
+            const {payload: {message}} = action;
+
+            yield call(addEvent, 'task.success', message);
+        });
+        replayApi.on('task.success', function (replayContext: ReplayContext, event) {
+            const message = event[2];
+
+            taskSuccessReducer(replayContext.state, {payload: {message}});
+        });
+
+        recordApi.on(ActionTypes.TaskSuccessClear, function* (addEvent) {
+            yield call(addEvent, 'task.success.clear');
+        });
+        replayApi.on('task.success.clear', function (replayContext: ReplayContext) {
+            taskSuccessClearReducer(replayContext.state);
         });
     });
 }

--- a/frontend/task/task.scss
+++ b/frontend/task/task.scss
@@ -337,7 +337,7 @@ body {
             width: 28px;
             height: 28px;
           }
-          &.bp3-icon-floppy-disk svg {
+          &.bp3-icon-floppy-disk svg, &.bp3-icon-repeat svg {
             width: 22px;
             height: 22px;
             margin: 3px;
@@ -358,6 +358,9 @@ body {
         width: 16px;
         height: 16px;
       }
+      &.time-duration {
+        padding-right: 20px;
+      }
     }
 
     .memory-usage {
@@ -375,7 +378,44 @@ body {
       display: flex;
       align-items: center;
       width: 100%;
-      padding: 0 10px;
+      padding: 0 15px;
+    }
+
+    .controls-mute {
+      border-right: solid 1px black;
+      .bp3-button {
+        border-right: none;
+        .bp3-icon {
+          color: #fff !important;
+          svg {
+            width: 22px;
+            height: 22px;
+            margin: 3px;
+          }
+        }
+      }
+
+      &:hover {
+        .player-controls-volume {
+          width: 150px;
+          padding: 0 30px;
+          .bp3-slider-handle {
+            display: block;
+          }
+        }
+      }
+    }
+
+    .player-controls-volume {
+      width: 0;
+      transition: width 0.2s, padding-left 0.2s, padding-right 0.2s;
+      .bp3-slider-handle {
+        display: none;
+        width: 20px !important;
+        &:after {
+          border-bottom: none !important;
+        }
+      }
     }
 
     .bp3-slider {

--- a/frontend/task/task.scss
+++ b/frontend/task/task.scss
@@ -484,3 +484,39 @@ pre, #app .ace_editor, .terminal, .stack-view, .subtitles-band-frame {
     }
   }
 }
+
+.simple-dialog {
+  border-radius: 5px;
+  background: #fff;
+  color: #787878;
+  padding: 20px;
+  width: 680px;
+
+  .simple-dialog-success {
+    color: green;
+    font-weight: bold;
+  }
+
+  .simple-dialog-buttons {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .simple-dialog-button {
+    padding: 5px 15px;
+    background-color: $primary;
+    color: #fff;
+    border-radius: 100px;
+    border: none;
+    box-shadow: none;
+    font-weight: bold;
+    text-transform: uppercase;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    .bp3-icon {
+      margin-right: 5px;
+    }
+  }
+}

--- a/frontend/task/task.scss
+++ b/frontend/task/task.scss
@@ -394,23 +394,13 @@ body {
           }
         }
       }
-
-      &:hover {
-        .player-controls-volume {
-          width: 150px;
-          padding: 0 30px;
-          .bp3-slider-handle {
-            display: block;
-          }
-        }
-      }
     }
 
     .player-controls-volume {
-      width: 0;
-      transition: width 0.2s, padding-left 0.2s, padding-right 0.2s;
+      width: 120px;
+      padding: 0 20px 0 10px;
       .bp3-slider-handle {
-        display: none;
+        display: block;
         width: 20px !important;
         &:after {
           border-bottom: none !important;


### PR DESCRIPTION
- Players controls added at the bottom of the page when we are replaying a recording
- Add in each context two methods `getCurrentState: () => ContextState` and `reloadState: (ContextState) => void` to handle local context state management so that we can do a seek anywhere in the recording and have the context state reloaded
- Handle errors, task success, speed and controls change in player