### PR TITLE
Define Codecast layout using XML

### DIFF
--- a/frontend/common/index.ts
+++ b/frontend/common/index.ts
@@ -15,6 +15,7 @@ import loginBundle from './login';
 import clientApiBundle from './client_api';
 import subtitlesBundle from '../subtitles';
 import taskBundle from '../task';
+import layoutBundle from '../task/layout/layout';
 import examplesBundle from './examples';
 import stepperBundle from '../stepper';
 import {Bundle} from "../linker";
@@ -43,6 +44,7 @@ export default function(bundle: Bundle) {
     bundle.include(examplesBundle);
 
     bundle.include(taskBundle);
+    bundle.include(layoutBundle);
 
     bundle.include(stepperBundle);
 }

--- a/frontend/lang/en-US.js
+++ b/frontend/lang/en-US.js
@@ -108,4 +108,5 @@ module.exports = {
     USER_SELECT_LOGIN_METHOD: "Select a login option:",
     TASK_DESCRIPTION: 'Instructions',
     TASK_VARIABLES: 'Variables',
+    TASK_VISUALIZATION: "Visualization {number}",
 };

--- a/frontend/lang/fr-FR.js
+++ b/frontend/lang/fr-FR.js
@@ -113,4 +113,5 @@ module.exports = {
 
     TASK_DESCRIPTION: 'Énoncé',
     TASK_VARIABLES: 'Variables',
+    TASK_VISUALIZATION: "Visualisation {number}",
 };

--- a/frontend/sandbox/SandboxApp.tsx
+++ b/frontend/sandbox/SandboxApp.tsx
@@ -5,6 +5,7 @@ import {StepperView} from "../stepper/views/StepperView";
 import {Menu} from "../common/Menu";
 import {connect} from "react-redux";
 import {AppStore} from "../store";
+import {ActionTypes} from "../task/actionTypes";
 
 interface SandboxAppStateToProps {
     containerWidth: number,
@@ -51,6 +52,10 @@ class _SandboxApp extends React.PureComponent<SandboxAppProps> {
             </div>
         );
     };
+
+    componentDidMount() {
+        this.props.dispatch({type: ActionTypes.TaskLoad});
+    }
 }
 
 export const SandboxApp = connect(mapStateToProps)(_SandboxApp);

--- a/frontend/store.ts
+++ b/frontend/store.ts
@@ -20,6 +20,7 @@ import {initialStateSubtitles} from "./subtitles";
 import {initialStateSave} from "./recorder/save_screen";
 import {initialStateTerminal} from "./stepper/io/terminal";
 import {TaskState} from "./task";
+import {LayoutState} from "./task/layout/layout";
 
 export type CodecastPlatform = 'python' | 'unix' | 'arduino';
 
@@ -89,6 +90,7 @@ export interface AppStore extends Store, AppStoreReplay {
     terminalElement: any,
     vumeterElement: any,
     task: TaskState,
+    layout: LayoutState,
 
     // TODO: Put the following in a "window" attribute instead of at the root of the store
     mainViewGeometry: typeof mainViewGeometries[0],

--- a/frontend/task/ContextVisualization.tsx
+++ b/frontend/task/ContextVisualization.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export class ContextVisualization extends React.PureComponent {
+    render() {
+        return (
+            <div className="task-visualisation">
+                <div id="grid"/>
+            </div>
+        );
+    }
+}

--- a/frontend/task/ControlsAndErrors.tsx
+++ b/frontend/task/ControlsAndErrors.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import {StepperControls} from "../stepper/views/StepperControls";
+import {ActionTypes as StepperActionTypes} from "../stepper/actionTypes";
+import {connect} from "react-redux";
+import {Icon} from "@blueprintjs/core";
+
+interface ControlsAndErrorsProps {
+    dispatch: Function,
+    error: string,
+    diagnostics: any,
+}
+
+function mapStateToProps() {
+    return {};
+}
+
+class _ControlsAndErrors extends React.PureComponent<ControlsAndErrorsProps> {
+    render() {
+        const {error, diagnostics} = this.props;
+        const hasError = !!(error || diagnostics);
+
+        return (
+            <div className="controls-and-errors">
+                <StepperControls enabled={true} newControls={true}/>
+                {hasError && <div className="error-message" onClick={this._onClearDiagnostics}>
+                  <button type="button" className="close-button" onClick={this._onClearDiagnostics}>
+                    <Icon icon="cross"/>
+                  </button>
+                  <div className="message-wrapper">
+                    <Icon icon="notifications" className="bell-icon"/>
+                    <div className="message">
+                        {diagnostics && <div dangerouslySetInnerHTML={diagnostics}/>}
+                        {error && <div>{error}</div>}
+                    </div>
+                  </div>
+                </div>}
+            </div>
+        );
+    }
+
+    _onClearDiagnostics = () => {
+        this.props.dispatch({type: StepperActionTypes.CompileClearDiagnostics});
+    };
+}
+
+export const ControlsAndErrors = connect(mapStateToProps)(_ControlsAndErrors);

--- a/frontend/task/MultiVisualization.tsx
+++ b/frontend/task/MultiVisualization.tsx
@@ -3,9 +3,13 @@ import {connect} from "react-redux";
 import {Dropdown} from 'react-bootstrap';
 import {Icon} from "@blueprintjs/core";
 import {IconName} from "@blueprintjs/icons";
+import {ActionTypes} from "./layout/actionTypes";
+import {AppStore} from "../store";
 
-function mapStateToProps() {
-
+function mapStateToProps(state: AppStore) {
+    return {
+        preferredVisualizations: state.layout.preferredVisualizations,
+    };
 }
 
 interface MultiVisualizationDispatchToProps {
@@ -94,9 +98,7 @@ class _MultiVisualization extends React.PureComponent<MultiVisualizationProps, M
     }
 
     selectVisualization = (id: string) => {
-        this.setState({
-            currentVisualization: id,
-        });
+        this.props.dispatch({type: ActionTypes.LayoutVisualizationSelected, payload: {visualization: id}})
     };
 }
 

--- a/frontend/task/MultiVisualization.tsx
+++ b/frontend/task/MultiVisualization.tsx
@@ -4,12 +4,10 @@ import {Dropdown} from 'react-bootstrap';
 import {Icon} from "@blueprintjs/core";
 import {IconName} from "@blueprintjs/icons";
 import {ActionTypes} from "./layout/actionTypes";
-import {AppStore} from "../store";
+import {LayoutVisualization} from "./layout/layout";
 
-function mapStateToProps(state: AppStore) {
-    return {
-        preferredVisualizations: state.layout.preferredVisualizations,
-    };
+function mapStateToProps() {
+    return {};
 }
 
 interface MultiVisualizationDispatchToProps {
@@ -17,13 +15,9 @@ interface MultiVisualizationDispatchToProps {
 }
 
 interface MultiVisualizationProps extends MultiVisualizationDispatchToProps {
-    children: React.ReactElement<{'data-title': string, 'data-id': string, 'data-icon'?: string}, any>[],
     className?: string,
-    advisedVisualization?: string,
-}
-
-interface MultiVisualizationState {
-    currentVisualization: string,
+    currentVisualization: LayoutVisualization,
+    visualizations: LayoutVisualization[],
 }
 
 const _CustomToggle = ({children, onClick}, ref) => (
@@ -43,55 +37,25 @@ const _CustomToggle = ({children, onClick}, ref) => (
 
 const CustomToggle = React.forwardRef<HTMLAnchorElement, {onClick: Function}>(_CustomToggle);
 
-class _MultiVisualization extends React.PureComponent<MultiVisualizationProps, MultiVisualizationState> {
-    state = {
-        currentVisualization: null,
-    };
-
-    componentDidUpdate(prevProps) {
-        if (prevProps.advisedVisualization !== this.props.advisedVisualization && this.props.advisedVisualization) {
-            this.setState({
-                currentVisualization: this.props.advisedVisualization,
-            })
-        }
-    }
-
+class _MultiVisualization extends React.PureComponent<MultiVisualizationProps> {
     render() {
-        const visualizations = React.Children.map(this.props.children, child => {
-            return {
-                id: child.props['data-id'],
-                title: child.props['data-title'],
-                icon: child.props['data-icon'],
-                element: child,
-            };
-        });
-
-        if (!visualizations) {
-            return null;
-        }
-
-        let currentVisualization = visualizations.find(visualization => (this.state.currentVisualization ?? this.props.advisedVisualization) === visualization.id);
-        if (!currentVisualization) {
-            currentVisualization = visualizations[0];
-        }
-
         return (
             <div className={`multi-visualization ${this.props.className}`}>
                 <Dropdown>
-                    <Dropdown.Toggle as={CustomToggle}>{currentVisualization.title}</Dropdown.Toggle>
+                    <Dropdown.Toggle as={CustomToggle}>{this.props.currentVisualization.metadata.title}</Dropdown.Toggle>
 
                     <Dropdown.Menu>
-                        {visualizations.map(visualization =>
-                            <Dropdown.Item key={visualization.id} onClick={() => this.selectVisualization(visualization.id)}>
-                                {visualization.icon && <Icon icon={visualization.icon as IconName}/>}
-                                <span>{visualization.title}</span>
+                        {this.props.visualizations.map(({metadata}) =>
+                            <Dropdown.Item key={metadata.id} onClick={() => this.selectVisualization(metadata.id)}>
+                                {metadata.icon && <Icon icon={metadata.icon as IconName}/>}
+                                <span>{metadata.title}</span>
                             </Dropdown.Item>
                         )}
                     </Dropdown.Menu>
                 </Dropdown>
 
                 <div className="multi-visualization-content">
-                    {currentVisualization.element}
+                    {this.props.currentVisualization.element}
                 </div>
             </div>
         );

--- a/frontend/task/TaskApp.tsx
+++ b/frontend/task/TaskApp.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
-import {StepperControls} from "../stepper/views/StepperControls";
 import {connect} from "react-redux";
 import {AppStore, CodecastOptions} from "../store";
-import {Col, Container, Row} from 'react-bootstrap';
-import {BufferEditor} from "../buffers/BufferEditor";
+import {Container} from 'react-bootstrap';
 import {getPlayerState} from "../player/selectors";
 import {Dialog, Icon, Intent, ProgressBar} from "@blueprintjs/core";
-import {ActionTypes as StepperActionTypes} from "../stepper/actionTypes";
 import {ActionTypes} from "./actionTypes";
 import {MenuTask} from "./MenuTask";
 import {RecorderControlsTask} from "./RecorderControlsTask";
@@ -14,10 +11,8 @@ import {SubtitlesBand} from "../subtitles/SubtitlesBand";
 import {PlayerError} from "../player";
 import {PlayerControlsTask} from "./PlayerControlsTask";
 import {ActionTypes as PlayerActionTypes} from "../player/actionTypes";
-import {MultiVisualization} from "./MultiVisualization";
-import {PythonStackView} from "../stepper/python/analysis/components/PythonStackView";
-import {StackView} from "../stepper/views/c/StackView";
 import {StepperStatus} from "../stepper";
+import {LayoutLoader} from "./layout/LayoutLoader";
 
 interface TaskAppStateToProps {
     readOnly: boolean,
@@ -128,8 +123,6 @@ class _TaskApp extends React.PureComponent<TaskAppProps, TaskAppState> {
             taskSuccess, taskSuccessMessage, advisedVisualization,
         } = this.props;
 
-        const hasError = !!(error || diagnostics);
-
         return (
             <Container fluid className={`task ${fullScreenActive ? 'full-screen' : ''}`}>
                 <div className="task-section">
@@ -138,61 +131,9 @@ class _TaskApp extends React.PureComponent<TaskAppProps, TaskAppState> {
                         <span className="task-header__algo">ALGO</span>
                     </div>
 
-                    <Row className="task-body" noGutters>
-                        <Col md={3} className="task-menu-left">
-                            <MultiVisualization className="visualization-container" advisedVisualization={advisedVisualization}>
-                                <div className="task-mission" data-title={getMessage('TASK_DESCRIPTION')} data-id="instructions" data-icon="align-left">
-                                    <h1>Votre mission</h1>
-
-                                    <p>Programmez le robot ci-dessous pour qu&#39;il atteigne l&#39;étoile, en sautant de plateforme en plateforme.</p>
-                                </div>
-                                <div data-title={getMessage('TASK_VARIABLES')} data-id="variables" data-icon="code">
-                                    {(this.props.currentStepperState && this.props.currentStepperState.platform === 'python')
-                                        ? <PythonStackView
-                                            height={this.props.sourceRowHeight}
-                                            analysis={this.props.currentStepperState.analysis}
-                                        />
-                                        : <StackView
-                                            height={this.props.sourceRowHeight}
-                                        />
-                                    }
-                                </div>
-                            </MultiVisualization>
-
-                            <hr/>
-
-                            <div className="task-visualisation">
-                                <div id="grid"/>
-                            </div>
-
-                            <div className="player-controls">
-                                <StepperControls enabled={true} newControls={true}/>
-                                {hasError && <div className="error-message" onClick={this._onClearDiagnostics}>
-                                  <button type="button" className="close-button" onClick={this._onClearDiagnostics}>
-                                    <Icon icon="cross"/>
-                                  </button>
-                                  <div className="message-wrapper">
-                                    <Icon icon="notifications" className="bell-icon"/>
-                                    <div className="message">
-                                        {diagnostics && <div dangerouslySetInnerHTML={diagnostics}/>}
-                                        {error && <div>{error}</div>}
-                                    </div>
-                                  </div>
-                                </div>}
-                            </div>
-                        </Col>
-                        <Col md={fullScreenActive ? 12 : 9}>
-                            <BufferEditor
-                                buffer='source'
-                                readOnly={readOnly}
-                                shield={preventInput}
-                                mode={sourceMode}
-                                theme={'textmate'}
-                                width='100%'
-                                height='100%'
-                            />
-                        </Col>
-                    </Row>
+                    <div className="task-body">
+                        <LayoutLoader/>
+                    </div>
 
                     {recordingEnabled &&
                         <div className="task-footer">
@@ -244,10 +185,6 @@ class _TaskApp extends React.PureComponent<TaskAppProps, TaskAppState> {
             });
         }
     }
-
-    _onClearDiagnostics = () => {
-        this.props.dispatch({type: StepperActionTypes.CompileClearDiagnostics});
-    };
 
     closeTaskSuccess = () => {
         this.props.dispatch({type: ActionTypes.TaskSuccessClear});

--- a/frontend/task/TaskApp.tsx
+++ b/frontend/task/TaskApp.tsx
@@ -8,93 +8,37 @@ import {ActionTypes} from "./actionTypes";
 import {MenuTask} from "./MenuTask";
 import {RecorderControlsTask} from "./RecorderControlsTask";
 import {SubtitlesBand} from "../subtitles/SubtitlesBand";
-import {PlayerError} from "../player";
 import {PlayerControlsTask} from "./PlayerControlsTask";
 import {ActionTypes as PlayerActionTypes} from "../player/actionTypes";
-import {StepperStatus} from "../stepper";
 import {LayoutLoader} from "./layout/LayoutLoader";
 
 interface TaskAppStateToProps {
-    readOnly: boolean,
-    sourceMode: string,
-    sourceRowHeight: number,
-    error: string,
-    geometry: any,
-    panes: any,
-    showStack: boolean,
-    arduinoEnabled: boolean,
-    showViews: boolean,
-    showIO: boolean,
-    windowHeight: any,
-    currentStepperState: any,
-    preventInput: any,
     fullScreenActive: boolean,
-    diagnostics: any,
     recordingEnabled: boolean,
     playerEnabled: boolean,
     isPlayerReady: boolean,
     playerProgress: number,
-    playerError: PlayerError,
     getMessage: Function,
     options: CodecastOptions,
     taskSuccess: boolean,
     taskSuccessMessage: string,
-    advisedVisualization: string,
 }
 
 function mapStateToProps(state: AppStore): TaskAppStateToProps {
     const getMessage = state.getMessage;
-    const geometry = state.mainViewGeometry;
-    const panes = state.panes;
     const fullScreenActive = state.fullscreen.active;
-    const currentStepperState = state.stepper.currentStepperState;
-    const readOnly = false;
-    const {showIO, showViews, showStack, platform} = state.options;
-    const arduinoEnabled = platform === 'arduino';
-    const diagnostics = state.compile.diagnosticsHtml;
-    const error = currentStepperState && currentStepperState.error;
     const recordingEnabled = state.task.recordingEnabled;
     const playerEnabled = !!state.options.baseDataUrl;
     const taskSuccess = state.task.success;
     const taskSuccessMessage = state.task.successMessage;
-
-    /* TODO: make number of visible rows in source editor configurable. */
-    const sourceRowHeight = Math.ceil(16 * 25); // 12*25 for /next
-
-    let mode;
-    switch (platform) {
-        case 'arduino':
-            mode = 'arduino';
-
-            break;
-        case 'python':
-            mode = 'python';
-
-            break;
-        default:
-            mode = 'c_cpp';
-
-            break;
-    }
-
-    const sourceMode = mode;
-
     const player = getPlayerState(state);
-    const preventInput = player.isPlaying;
     const isPlayerReady = player.isReady;
     const playerProgress = player.progress;
-    const playerError = player.error;
-    const windowHeight = state.windowHeight;
     const options = state.options;
 
-    const advisedVisualization = !state.stepper || state.stepper.status === StepperStatus.Clear ? 'instructions' : 'variables';
-
     return {
-        readOnly, error, getMessage, geometry, panes, sourceRowHeight,
-        sourceMode, showStack, arduinoEnabled, showViews, showIO, windowHeight,
-        currentStepperState, fullScreenActive, diagnostics, recordingEnabled,
-        preventInput, isPlayerReady, playerProgress, playerError, playerEnabled,
-        options, taskSuccess, taskSuccessMessage, advisedVisualization,
+        fullScreenActive, recordingEnabled, playerProgress, isPlayerReady,
+        playerEnabled, getMessage, taskSuccess, taskSuccessMessage, options,
     };
 }
 
@@ -115,12 +59,8 @@ class _TaskApp extends React.PureComponent<TaskAppProps, TaskAppState> {
 
     render() {
         const {
-            readOnly, sourceMode, error,
-            preventInput, fullScreenActive,
-            diagnostics, recordingEnabled,
-            playerProgress, isPlayerReady,
-            playerEnabled, getMessage,
-            taskSuccess, taskSuccessMessage, advisedVisualization,
+            fullScreenActive, recordingEnabled, playerProgress, isPlayerReady,
+            playerEnabled, getMessage, taskSuccess, taskSuccessMessage,
         } = this.props;
 
         return (

--- a/frontend/task/TaskInstructions.tsx
+++ b/frontend/task/TaskInstructions.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export class TaskInstructions extends React.PureComponent {
+    render() {
+        return (
+            <div className="task-mission">
+                <h1>Votre mission</h1>
+
+                <p>Programmez le robot ci-dessous pour qu&#39;il atteigne l&#39;étoile, en sautant de plateforme en plateforme.</p>
+            </div>
+        );
+    }
+}

--- a/frontend/task/layout/DefaultLayoutDesktop.xml
+++ b/frontend/task/layout/DefaultLayoutDesktop.xml
@@ -1,0 +1,26 @@
+<HorizontalLayout>
+    <VerticalLayout desiredSize="40%">
+        <ZoneLayout name="top-left">
+            <Instructions/>
+            <Variables/>
+        </ZoneLayout>
+        <ZoneLayout name="center-left">
+            <ContextVisualization/>
+        </ZoneLayout>
+        <ZoneLayout name="bottom-left">
+            <ControlsAndErrors/>
+        </ZoneLayout>
+    </VerticalLayout>
+    <VerticalLayout desiredSize="60%">
+        <ZoneLayout name="center-top"/>
+        <ZoneLayout name="center">
+            <Editor/>
+        </ZoneLayout>
+        <ZoneLayout name="center-bottom"/>
+    </VerticalLayout>
+    <VerticalLayout>
+        <ZoneLayout name="top-right"/>
+        <ZoneLayout name="center-right"/>
+        <ZoneLayout name="bottom-right"/>
+    </VerticalLayout>
+</HorizontalLayout>

--- a/frontend/task/layout/LayoutLoader.tsx
+++ b/frontend/task/layout/LayoutLoader.tsx
@@ -1,56 +1,23 @@
 import React from "react";
 import {connect} from "react-redux";
-import {AppStore, CodecastOptions} from "../../store";
+import {AppStore} from "../../store";
 import {getPlayerState} from "../../player/selectors";
+import {createLayout, LayoutProps} from "./layout";
 import {StepperStatus} from "../../stepper";
-import {PlayerError} from "../../player";
-import {createLayout} from "./layout";
+import {ActionTypes} from "./actionTypes";
 
-interface LayoutLoaderStateToProps {
-    readOnly: boolean,
-    sourceMode: string,
-    sourceRowHeight: number,
-    error: string,
-    geometry: any,
-    panes: any,
-    showStack: boolean,
-    arduinoEnabled: boolean,
-    showViews: boolean,
-    showIO: boolean,
-    windowHeight: any,
-    currentStepperState: any,
-    preventInput: any,
-    fullScreenActive: boolean,
-    diagnostics: any,
-    recordingEnabled: boolean,
-    playerEnabled: boolean,
-    isPlayerReady: boolean,
-    playerProgress: number,
-    playerError: PlayerError,
-    getMessage: Function,
-    options: CodecastOptions,
-    taskSuccess: boolean,
-    taskSuccessMessage: string,
+interface LayoutLoaderStateToProps extends LayoutProps {
     advisedVisualization: string,
 }
 
 function mapStateToProps(state: AppStore): LayoutLoaderStateToProps {
     const getMessage = state.getMessage;
-    const geometry = state.mainViewGeometry;
-    const panes = state.panes;
     const fullScreenActive = state.fullscreen.active;
     const currentStepperState = state.stepper.currentStepperState;
     const readOnly = false;
-    const {showIO, showViews, showStack, platform} = state.options;
-    const arduinoEnabled = platform === 'arduino';
+    const {platform} = state.options;
     const diagnostics = state.compile.diagnosticsHtml;
     const error = currentStepperState && currentStepperState.error;
-    const recordingEnabled = state.task.recordingEnabled;
-    const playerEnabled = !!state.options.baseDataUrl;
-    const taskSuccess = state.task.success;
-    const taskSuccessMessage = state.task.successMessage;
-
-    /* TODO: make number of visible rows in source editor configurable. */
     const sourceRowHeight = Math.ceil(16 * 25); // 12*25 for /next
 
     let mode;
@@ -73,27 +40,32 @@ function mapStateToProps(state: AppStore): LayoutLoaderStateToProps {
 
     const player = getPlayerState(state);
     const preventInput = player.isPlaying;
-    const isPlayerReady = player.isReady;
-    const playerProgress = player.progress;
-    const playerError = player.error;
-    const windowHeight = state.windowHeight;
-    const options = state.options;
 
     const advisedVisualization = !state.stepper || state.stepper.status === StepperStatus.Clear ? 'instructions' : 'variables';
 
     return {
-        readOnly, error, getMessage, geometry, panes, sourceRowHeight,
-        sourceMode, showStack, arduinoEnabled, showViews, showIO, windowHeight,
-        currentStepperState, fullScreenActive, diagnostics, recordingEnabled,
-        preventInput, isPlayerReady, playerProgress, playerError, playerEnabled,
-        options, taskSuccess, taskSuccessMessage, advisedVisualization,
+        readOnly, error, getMessage, sourceRowHeight, sourceMode,
+        currentStepperState, fullScreenActive, diagnostics, preventInput, advisedVisualization,
     };
 }
 
-interface LayoutLoaderProps extends LayoutLoaderStateToProps {
+interface LayoutLoaderDispatchToProps {
+    dispatch: Function
+}
+
+interface LayoutLoaderProps extends LayoutLoaderStateToProps, LayoutLoaderDispatchToProps {
 }
 
 class _LayoutLoader extends React.PureComponent<LayoutLoaderProps> {
+    componentDidUpdate(prevProps) {
+        if (prevProps.advisedVisualization !== this.props.advisedVisualization && this.props.advisedVisualization) {
+            this.props.dispatch({
+                type: ActionTypes.LayoutVisualizationSelected,
+                payload: {visualization: this.props.advisedVisualization}
+            });
+        }
+    }
+
     render() {
         return createLayout(this.props);
     }

--- a/frontend/task/layout/LayoutLoader.tsx
+++ b/frontend/task/layout/LayoutLoader.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import {connect} from "react-redux";
+import {AppStore, CodecastOptions} from "../../store";
+import {getPlayerState} from "../../player/selectors";
+import {StepperStatus} from "../../stepper";
+import {PlayerError} from "../../player";
+import {createLayout} from "./layout";
+
+interface LayoutLoaderStateToProps {
+    readOnly: boolean,
+    sourceMode: string,
+    sourceRowHeight: number,
+    error: string,
+    geometry: any,
+    panes: any,
+    showStack: boolean,
+    arduinoEnabled: boolean,
+    showViews: boolean,
+    showIO: boolean,
+    windowHeight: any,
+    currentStepperState: any,
+    preventInput: any,
+    fullScreenActive: boolean,
+    diagnostics: any,
+    recordingEnabled: boolean,
+    playerEnabled: boolean,
+    isPlayerReady: boolean,
+    playerProgress: number,
+    playerError: PlayerError,
+    getMessage: Function,
+    options: CodecastOptions,
+    taskSuccess: boolean,
+    taskSuccessMessage: string,
+    advisedVisualization: string,
+}
+
+function mapStateToProps(state: AppStore): LayoutLoaderStateToProps {
+    const getMessage = state.getMessage;
+    const geometry = state.mainViewGeometry;
+    const panes = state.panes;
+    const fullScreenActive = state.fullscreen.active;
+    const currentStepperState = state.stepper.currentStepperState;
+    const readOnly = false;
+    const {showIO, showViews, showStack, platform} = state.options;
+    const arduinoEnabled = platform === 'arduino';
+    const diagnostics = state.compile.diagnosticsHtml;
+    const error = currentStepperState && currentStepperState.error;
+    const recordingEnabled = state.task.recordingEnabled;
+    const playerEnabled = !!state.options.baseDataUrl;
+    const taskSuccess = state.task.success;
+    const taskSuccessMessage = state.task.successMessage;
+
+    /* TODO: make number of visible rows in source editor configurable. */
+    const sourceRowHeight = Math.ceil(16 * 25); // 12*25 for /next
+
+    let mode;
+    switch (platform) {
+        case 'arduino':
+            mode = 'arduino';
+
+            break;
+        case 'python':
+            mode = 'python';
+
+            break;
+        default:
+            mode = 'c_cpp';
+
+            break;
+    }
+
+    const sourceMode = mode;
+
+    const player = getPlayerState(state);
+    const preventInput = player.isPlaying;
+    const isPlayerReady = player.isReady;
+    const playerProgress = player.progress;
+    const playerError = player.error;
+    const windowHeight = state.windowHeight;
+    const options = state.options;
+
+    const advisedVisualization = !state.stepper || state.stepper.status === StepperStatus.Clear ? 'instructions' : 'variables';
+
+    return {
+        readOnly, error, getMessage, geometry, panes, sourceRowHeight,
+        sourceMode, showStack, arduinoEnabled, showViews, showIO, windowHeight,
+        currentStepperState, fullScreenActive, diagnostics, recordingEnabled,
+        preventInput, isPlayerReady, playerProgress, playerError, playerEnabled,
+        options, taskSuccess, taskSuccessMessage, advisedVisualization,
+    };
+}
+
+interface LayoutLoaderProps extends LayoutLoaderStateToProps {
+}
+
+class _LayoutLoader extends React.PureComponent<LayoutLoaderProps> {
+    render() {
+        return createLayout(this.props);
+    }
+}
+
+export const LayoutLoader = connect(mapStateToProps)(_LayoutLoader);

--- a/frontend/task/layout/RelativeLayout.tsx
+++ b/frontend/task/layout/RelativeLayout.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {LayoutElementMetadata} from "./layout";
+
+export enum RelativeLayoutOrientation {
+    HORIZONTAL = 'horizontal',
+    VERTICAL = 'vertical',
+}
+
+interface RelativeLayoutProps {
+    orientation: RelativeLayoutOrientation,
+    metadata: LayoutElementMetadata,
+}
+
+export class RelativeLayout extends React.PureComponent<RelativeLayoutProps> {
+    render() {
+        const childrenRendered = (
+            <React.Fragment>
+                {this.props.children}
+            </React.Fragment>
+        );
+
+        const style: React.CSSProperties = this.props.metadata.desiredSize ? {flexBasis: this.props.metadata.desiredSize} : {flex: '1 0'};
+
+        return (
+            <div className={`relative-layout is-${this.props.orientation}`} style={style}>
+                {childrenRendered}
+            </div>
+        );
+    }
+}

--- a/frontend/task/layout/ZoneLayout.tsx
+++ b/frontend/task/layout/ZoneLayout.tsx
@@ -1,0 +1,49 @@
+import React, {ReactElement} from 'react';
+import {MultiVisualization} from "../MultiVisualization";
+
+interface ZoneLayoutProps {
+    name: string,
+}
+
+export class ZoneLayout extends React.PureComponent<ZoneLayoutProps> {
+    render() {
+        const children = React.Children.toArray(this.props.children);
+        if (!children.length) {
+            return null;
+        }
+
+        const elements = children.map(child => {
+            return {
+                metadata: (child as ReactElement).props.metadata ?? {},
+                element: child,
+            };
+        });
+
+        if (elements.length > 1) {
+            return (
+                <div className="zone-layout">
+                    <MultiVisualization className="visualization-container" advisedVisualization={null}>
+                        {elements.map(({metadata, element}) =>
+                            <div key={metadata.id} data-title={metadata.title} data-id={metadata.id} data-icon={metadata.icon}>
+                                {element}
+                            </div>
+                        )}
+                    </MultiVisualization>
+                </div>
+            );
+        } else {
+            const {metadata, element} = elements[0];
+            const hasDesiredSize = !!metadata.desiredSize;
+            const style: React.CSSProperties = hasDesiredSize ? {flexBasis: metadata.desiredSize} : {flex: '1 0'};
+            if (false !== metadata.overflow) {
+                style.overflow = 'auto';
+            }
+
+            return (
+                <div className="zone-layout" style={style}>
+                    {element}
+                </div>
+            );
+        }
+    }
+}

--- a/frontend/task/layout/ZoneLayout.tsx
+++ b/frontend/task/layout/ZoneLayout.tsx
@@ -1,44 +1,84 @@
 import React, {ReactElement} from 'react';
 import {MultiVisualization} from "../MultiVisualization";
+import {AppStore} from "../../store";
+import {connect} from "react-redux";
+import {LayoutElementMetadata, LayoutVisualization} from "./layout";
 
-interface ZoneLayoutProps {
-    name: string,
+function mapStateToProps(state: AppStore) {
+    return {
+        preferredVisualizations: state.layout.preferredVisualizations,
+        getMessage: state.getMessage,
+    };
 }
 
-export class ZoneLayout extends React.PureComponent<ZoneLayoutProps> {
+interface ZoneLayoutStateToProps {
+    preferredVisualizations: string[],
+    getMessage: Function,
+}
+
+interface ZoneLayoutProps extends ZoneLayoutStateToProps {
+    name: string,
+    metadata: LayoutElementMetadata,
+}
+
+class _ZoneLayout extends React.PureComponent<ZoneLayoutProps> {
     render() {
         const children = React.Children.toArray(this.props.children);
         if (!children.length) {
             return null;
         }
 
-        const elements = children.map(child => {
-            return {
-                metadata: (child as ReactElement).props.metadata ?? {},
-                element: child,
+        let visualizationCount = 0;
+        const visualizations = children.map(child => {
+            visualizationCount++;
+
+            const defaultMetadata = {
+                id: "visualization-" + visualizationCount,
+                title: this.props.getMessage('TASK_VISUALIZATION').format({number: visualizationCount}),
+                icon: null,
             };
+
+            return {
+                metadata: {...defaultMetadata, ...(child as ReactElement).props.metadata} as LayoutElementMetadata,
+                element: child,
+            } as LayoutVisualization;
         });
 
-        if (elements.length > 1) {
+        if (!visualizations.length) {
+            return null;
+        }
+
+        let currentVisualization = visualizations[0];
+        if (visualizations.length > 1) {
+            let visualizationsRankPreference = visualizations
+                .map(({metadata: {id}}) => ({id, rank: this.props.preferredVisualizations.indexOf(id)}))
+                .filter(({rank}) => -1 !== rank);
+
+            if (visualizationsRankPreference.length) {
+                visualizationsRankPreference.sort(({rank: rank1}, {rank: rank2}) => rank2 - rank1);
+                const preferredVisualizationId = visualizationsRankPreference[0].id;
+                currentVisualization = visualizations.find(({metadata: {id}}) => id === preferredVisualizationId);
+            }
+        }
+
+        const {metadata, element} = currentVisualization;
+        const hasDesiredSize = !!metadata.desiredSize;
+        const style: React.CSSProperties = hasDesiredSize ? {flexBasis: metadata.desiredSize} : {flex: '1 0'};
+        if (false !== metadata.overflow) {
+            style.overflow = 'auto';
+        }
+
+        if (visualizations.length > 1) {
             return (
-                <div className="zone-layout">
-                    <MultiVisualization className="visualization-container" advisedVisualization={null}>
-                        {elements.map(({metadata, element}) =>
-                            <div key={metadata.id} data-title={metadata.title} data-id={metadata.id} data-icon={metadata.icon}>
-                                {element}
-                            </div>
-                        )}
-                    </MultiVisualization>
+                <div className="zone-layout" style={style}>
+                    <MultiVisualization
+                        className="visualization-container"
+                        visualizations={visualizations}
+                        currentVisualization={currentVisualization}
+                    />
                 </div>
             );
         } else {
-            const {metadata, element} = elements[0];
-            const hasDesiredSize = !!metadata.desiredSize;
-            const style: React.CSSProperties = hasDesiredSize ? {flexBasis: metadata.desiredSize} : {flex: '1 0'};
-            if (false !== metadata.overflow) {
-                style.overflow = 'auto';
-            }
-
             return (
                 <div className="zone-layout" style={style}>
                     {element}
@@ -47,3 +87,6 @@ export class ZoneLayout extends React.PureComponent<ZoneLayoutProps> {
         }
     }
 }
+
+export const ZoneLayout = connect(mapStateToProps)(_ZoneLayout);
+

--- a/frontend/task/layout/actionTypes.ts
+++ b/frontend/task/layout/actionTypes.ts
@@ -1,0 +1,3 @@
+export enum ActionTypes {
+  LayoutVisualizationSelected = 'Layout.Visualization.Selected',
+}

--- a/frontend/task/layout/layout.scss
+++ b/frontend/task/layout/layout.scss
@@ -1,0 +1,8 @@
+.relative-layout {
+  display: flex;
+  align-items: stretch;
+  flex: 1 0;
+  &.is-vertical {
+    flex-direction: column;
+  }
+}

--- a/frontend/task/layout/layout.ts
+++ b/frontend/task/layout/layout.ts
@@ -1,0 +1,296 @@
+import {RelativeLayout, RelativeLayoutOrientation} from "./RelativeLayout";
+import {ZoneLayout} from "./ZoneLayout";
+import {BufferEditor} from "../../buffers/BufferEditor";
+import {TaskInstructions} from "../TaskInstructions";
+import {ContextVisualization} from "../ContextVisualization";
+import {PythonStackView} from "../../stepper/python/analysis/components/PythonStackView";
+import {StackView} from "../../stepper/views/c/StackView";
+import {DOMParser} from 'xmldom';
+import {createElement, ReactElement, ReactNode} from 'react';
+import {PlayerError} from "../../player";
+import {AppStore, CodecastOptions} from "../../store";
+import {ControlsAndErrors} from "../ControlsAndErrors";
+import {Bundle} from "../../linker";
+import {ActionTypes} from "./actionTypes";
+import {QuickAlgoContext} from "../index";
+import {ActionTypes as AppActionTypes} from "../../actionTypes";
+
+function validateConverters(converters: Converters): boolean {
+    if (typeof converters !== 'object' || !converters) {
+        return false;
+    }
+
+    const keys = Object.keys(converters);
+    const isEmpty = !keys.length;
+    if (isEmpty) {
+        return false;
+    }
+
+    const isFunction = key => (typeof converters[key] === 'function');
+
+    return keys.every(isFunction);
+}
+
+function getAttributes(node) {
+    if (!node) {
+        return {};
+    }
+
+    const {attributes} = node;
+    if (!attributes || !attributes.length) {
+        return {};
+    }
+
+    const result = {};
+
+    Array.from(attributes)
+        .forEach(({ name, value }) => {
+            result[name] = value;
+        });
+
+    return result;
+}
+
+function getChildren(node) {
+    if (!node) {
+        return [];
+    }
+
+    const { childNodes: children } = node;
+
+    if (!children) {
+        return [];
+    }
+
+    return children.length ? Array.from(children) : [];
+}
+
+function visitNode(node, index, converters, data): ReactElement {
+    if (!node) {
+        return null;
+    }
+
+    const { tagName, nodeType } = node;
+    if (nodeType === 3 && node.nodeValue.trim().length) {
+        return node.nodeValue;
+    }
+
+    if (!tagName) {
+        return null;
+    }
+
+    const converter = converters[tagName];
+
+    if (typeof converter !== 'function') {
+        return null;
+    }
+
+    const attributes = getAttributes(node);
+    const {type, metadata, props} = converter(attributes, data);
+    const newProps = Object.assign({}, {key: index}, props);
+    newProps.metadata = metadata ?? {};
+
+    const children = getChildren(node);
+    const visitChildren = (child, childIndex) => visitNode(child, childIndex, converters, data);
+    const childElements = children.map(visitChildren).filter(child => null !== child);
+    if ((type === ZoneLayout || type === RelativeLayout) && !childElements.length) {
+        return null;
+    }
+
+    return createElement(type, newProps, ...childElements);
+}
+
+class XMLToReact {
+    private readonly converters: Converters;
+    private readonly xmlParser: DOMParser;
+
+    constructor(converters: Converters) {
+        const isValid = validateConverters(converters);
+        if (!isValid) {
+            throw new Error('Invalid value for converter map argument. Please use an object with functions as values.');
+        }
+
+        this.converters = converters;
+
+        const throwError = (m) => { throw new Error(m); };
+        this.xmlParser = new DOMParser({
+            errorHandler: throwError,
+            fatalError: throwError,
+            warning: throwError,
+        });
+    }
+
+    convert(xml: string, data = {}) {
+        if (typeof xml !== 'string') {
+            return null;
+        }
+
+        const tree = this.parseXml(xml);
+        if (!tree) {
+            return null;
+        }
+
+        return visitNode(tree.documentElement, 0, this.converters, data);
+    }
+
+    parseXml(xml: string) {
+        if (typeof xml !== 'string') {
+            return null;
+        }
+
+        try {
+            return this.xmlParser.parseFromString(xml, 'text/xml');
+        } catch (e) {
+            console.warn('Unable to parse invalid XML input. Please input valid XML.'); // eslint-disable-line no-console
+        }
+
+        return null;
+    }
+}
+
+interface Converters {
+    [key: string]: (attrs: object) => ({type: ReactNode, metadata?: LayoutElementMetadata, props?: object})
+}
+
+interface LayoutProps {
+    readOnly: boolean,
+    sourceMode: string,
+    sourceRowHeight: number,
+    error: string,
+    geometry: any,
+    panes: any,
+    showStack: boolean,
+    arduinoEnabled: boolean,
+    showViews: boolean,
+    showIO: boolean,
+    windowHeight: any,
+    currentStepperState: any,
+    preventInput: any,
+    fullScreenActive: boolean,
+    diagnostics: any,
+    recordingEnabled: boolean,
+    playerEnabled: boolean,
+    isPlayerReady: boolean,
+    playerProgress: number,
+    playerError: PlayerError,
+    getMessage: Function,
+    options: CodecastOptions,
+    taskSuccess: boolean,
+    taskSuccessMessage: string,
+    advisedVisualization: string,
+}
+
+export interface LayoutElementMetadata {
+    id?: string,
+    title?: string,
+    icon?: string,
+    overflow?: boolean,
+    desiredSize?: string,
+}
+
+export function createLayout(layoutProps: LayoutProps): ReactElement {
+    const xmlToReact = new XMLToReact({
+        HorizontalLayout: (attrs) => ({
+            type: RelativeLayout,
+            metadata: attrs,
+            props: {
+                orientation: RelativeLayoutOrientation.HORIZONTAL,
+            }
+        }),
+        VerticalLayout: (attrs) => ({
+            type: RelativeLayout,
+            metadata: attrs,
+            props: {
+                orientation: RelativeLayoutOrientation.VERTICAL,
+            }
+        }),
+        ZoneLayout: (attrs) => ({
+            type: ZoneLayout,
+            metadata: attrs,
+        }),
+        ControlsAndErrors: (attrs) => ({
+            type: ControlsAndErrors,
+            metadata: {
+                desiredSize: '0px',
+                overflow: false,
+                ...attrs,
+            },
+            props: {
+                error: layoutProps.error,
+                diagnostics: layoutProps.diagnostics,
+            }
+        }),
+        Editor: (attrs) => ({
+            type: BufferEditor,
+            metadata: attrs,
+            props: {
+                buffer: 'source',
+                readOnly: layoutProps.readOnly,
+                shield: layoutProps.preventInput,
+                mode: layoutProps.sourceMode,
+                theme: 'textmate',
+                width: '100%',
+                height: '100%',
+            }
+        }),
+        Instructions: (attrs) => ({
+            type: TaskInstructions,
+            metadata: {
+                id: 'instructions',
+                title: layoutProps.getMessage('TASK_DESCRIPTION'),
+                icon: 'align-left',
+            },
+        }),
+        ContextVisualization: (attrs) => ({
+            type: ContextVisualization,
+            metadata: attrs,
+        }),
+        Variables: (attrs) => ({
+            type: (layoutProps.currentStepperState && layoutProps.currentStepperState.platform === 'python') ? PythonStackView : StackView,
+            metadata: {
+                id: 'variables',
+                title: layoutProps.getMessage('TASK_VARIABLES'),
+                icon: 'code',
+                ...attrs,
+            },
+            props: {
+                height: layoutProps.sourceRowHeight,
+                analysis: layoutProps.currentStepperState ? layoutProps.currentStepperState.analysis : null,
+            },
+        }),
+        // <DirectivesPane scale={1}/>
+    });
+
+    let layoutXml = require('./DefaultLayoutDesktop.xml').default;
+    if (layoutProps.fullScreenActive) {
+        layoutXml = '<Editor/>';
+    }
+
+    console.log(layoutXml);
+    const xmlParsed = xmlToReact.convert(layoutXml);
+    console.log({xmlParsed});
+
+    return xmlParsed;
+}
+
+function layoutVisualizationSelectedReducer(state: AppStore, {payload: {visualization}}) {
+    if (-1 !== state.layout.preferredVisualizations.indexOf(visualization)) {
+        state.layout.preferredVisualizations.splice(state.layout.preferredVisualizations.indexOf(visualization), 1);
+    }
+    state.layout.preferredVisualizations.push(visualization);
+}
+
+export interface LayoutState {
+    preferredVisualizations: string[], // least preferred at the beginning, most preferred at the end
+}
+
+export default function (bundle: Bundle) {
+    bundle.addReducer(AppActionTypes.AppInit, (state: AppStore) => {
+        state.layout = {
+            preferredVisualizations: [],
+        };
+    });
+
+    bundle.defineAction(ActionTypes.LayoutVisualizationSelected);
+    bundle.addReducer(ActionTypes.LayoutVisualizationSelected, layoutVisualizationSelectedReducer);
+};

--- a/frontend/task/layout/layout.ts
+++ b/frontend/task/layout/layout.ts
@@ -7,12 +7,10 @@ import {PythonStackView} from "../../stepper/python/analysis/components/PythonSt
 import {StackView} from "../../stepper/views/c/StackView";
 import {DOMParser} from 'xmldom';
 import {createElement, ReactElement, ReactNode} from 'react';
-import {PlayerError} from "../../player";
 import {AppStore, CodecastOptions} from "../../store";
 import {ControlsAndErrors} from "../ControlsAndErrors";
 import {Bundle} from "../../linker";
 import {ActionTypes} from "./actionTypes";
-import {QuickAlgoContext} from "../index";
 import {ActionTypes as AppActionTypes} from "../../actionTypes";
 
 function validateConverters(converters: Converters): boolean {
@@ -152,32 +150,16 @@ interface Converters {
     [key: string]: (attrs: object) => ({type: ReactNode, metadata?: LayoutElementMetadata, props?: object})
 }
 
-interface LayoutProps {
+export interface LayoutProps {
     readOnly: boolean,
     sourceMode: string,
     sourceRowHeight: number,
     error: string,
-    geometry: any,
-    panes: any,
-    showStack: boolean,
-    arduinoEnabled: boolean,
-    showViews: boolean,
-    showIO: boolean,
-    windowHeight: any,
     currentStepperState: any,
     preventInput: any,
     fullScreenActive: boolean,
     diagnostics: any,
-    recordingEnabled: boolean,
-    playerEnabled: boolean,
-    isPlayerReady: boolean,
-    playerProgress: number,
-    playerError: PlayerError,
     getMessage: Function,
-    options: CodecastOptions,
-    taskSuccess: boolean,
-    taskSuccessMessage: string,
-    advisedVisualization: string,
 }
 
 export interface LayoutElementMetadata {
@@ -186,6 +168,11 @@ export interface LayoutElementMetadata {
     icon?: string,
     overflow?: boolean,
     desiredSize?: string,
+}
+
+export interface LayoutVisualization {
+    metadata: LayoutElementMetadata,
+    element: ReactElement,
 }
 
 export function createLayout(layoutProps: LayoutProps): ReactElement {
@@ -239,6 +226,7 @@ export function createLayout(layoutProps: LayoutProps): ReactElement {
                 id: 'instructions',
                 title: layoutProps.getMessage('TASK_DESCRIPTION'),
                 icon: 'align-left',
+                ...attrs,
             },
         }),
         ContextVisualization: (attrs) => ({
@@ -266,18 +254,20 @@ export function createLayout(layoutProps: LayoutProps): ReactElement {
         layoutXml = '<Editor/>';
     }
 
-    console.log(layoutXml);
-    const xmlParsed = xmlToReact.convert(layoutXml);
-    console.log({xmlParsed});
-
-    return xmlParsed;
+    return xmlToReact.convert(layoutXml);
 }
 
 function layoutVisualizationSelectedReducer(state: AppStore, {payload: {visualization}}) {
-    if (-1 !== state.layout.preferredVisualizations.indexOf(visualization)) {
-        state.layout.preferredVisualizations.splice(state.layout.preferredVisualizations.indexOf(visualization), 1);
+    makeVisualizationAsPreferred(state.layout.preferredVisualizations, visualization);
+}
+
+export function makeVisualizationAsPreferred(visualizations: string[], visualization: string): string[] {
+    if (-1 !== visualizations.indexOf(visualization)) {
+        visualizations.splice(visualizations.indexOf(visualization), 1);
     }
-    state.layout.preferredVisualizations.push(visualization);
+    visualizations.push(visualization);
+
+    return visualizations;
 }
 
 export interface LayoutState {

--- a/frontend/task/layout/layout.ts
+++ b/frontend/task/layout/layout.ts
@@ -7,7 +7,7 @@ import {PythonStackView} from "../../stepper/python/analysis/components/PythonSt
 import {StackView} from "../../stepper/views/c/StackView";
 import {DOMParser} from 'xmldom';
 import {createElement, ReactElement, ReactNode} from 'react';
-import {AppStore, CodecastOptions} from "../../store";
+import {AppStore} from "../../store";
 import {ControlsAndErrors} from "../ControlsAndErrors";
 import {Bundle} from "../../linker";
 import {ActionTypes} from "./actionTypes";
@@ -242,11 +242,9 @@ export function createLayout(layoutProps: LayoutProps): ReactElement {
                 ...attrs,
             },
             props: {
-                height: layoutProps.sourceRowHeight,
                 analysis: layoutProps.currentStepperState ? layoutProps.currentStepperState.analysis : null,
             },
         }),
-        // <DirectivesPane scale={1}/>
     });
 
     let layoutXml = require('./DefaultLayoutDesktop.xml').default;

--- a/frontend/task/task.scss
+++ b/frontend/task/task.scss
@@ -1,5 +1,7 @@
 $primary: #4e94e3;
 
+@import "./layout/layout.scss";
+
 html {
   margin: 0 !important;
 }
@@ -41,10 +43,12 @@ body {
 
   .task-body {
     flex: 1 0;
+    height: calc(100vh - 50px);
+    background: #fff;
+    display: flex;
   }
 
-  .task-menu-left {
-    background: #fff;
+  .task-zone-left, .task-zone-right {
     display: flex;
     flex-direction: column;
   }
@@ -62,6 +66,10 @@ body {
   hr {
     width: 100%;
     border-bottom: solid 1px #e7e7e7;
+  }
+
+  .controls-and-errors {
+    position: relative;
   }
 
   .controls-stepper {
@@ -185,7 +193,7 @@ body {
     right: 0;
     bottom: 0;
     left: 0;
-    padding: 11px 0;
+    padding: 14px 0;
     color: #fff;
     z-index: 1;
     border-radius: 5px 5px 0 0;
@@ -229,12 +237,16 @@ body {
   }
 
   .task-visualisation {
-    flex: 1 0;
-    padding: 40px;
+    padding: 20px;
+  }
+
+  .visualization-slot {
+    overflow: auto;
+    flex-basis: 50%;
   }
 
   &.full-screen {
-    .task-header, .task-footer, .task-menu-left {
+    .task-header, .task-footer, .task-zone-left {
       display: none;
     }
     .task-body {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "pug": "^3.0.2",
     "query-string": "^6.14.1",
     "randomstring": "^1.1.5",
+    "raw-loader": "^4.0.2",
     "rc-slider": "^9.7.1",
     "react": "^17.0.1",
     "react-bootstrap": "^1.5.1",
@@ -92,7 +93,8 @@
     "typeface-inconsolata": "^1.1.13",
     "typeface-open-sans": "^1.1.13",
     "url-join": "^4.0.1",
-    "walkdir": "^0.4.1"
+    "walkdir": "^0.4.1",
+    "xmldom": "^0.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,8 +136,14 @@ module.exports = (env, argv) => {
                     use: [
                         {loader: 'file-loader?context=public&name=images/[name].[ext]'}
                     ]
-                }
-            ]
+                },
+                {
+                    test: /\.xml$/,
+                    use : [
+                        {loader: 'raw-loader'}
+                    ],
+                },
+            ],
         },
         plugins: [
             new webpack.DefinePlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2283,15 +2283,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001157:
-  version "1.0.30001159"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz#bebde28f893fa9594dadcaa7d6b8e2aa0299df20"
-  integrity sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==
-
-caniuse-lite@^1.0.30001181:
-  version "1.0.30001197"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz#47ad15b977d2f32b3ec2fe2b087e0c50443771db"
-  integrity sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==
+caniuse-lite@^1.0.30001157, caniuse-lite@^1.0.30001181:
+  version "1.0.30001214"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz"
+  integrity sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -6274,6 +6269,14 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+raw-loader@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
+  integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 rc-align@^4.0.0:
   version "4.0.9"
   resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-4.0.9.tgz#46d8801c4a139ff6a65ad1674e8efceac98f85f2"
@@ -8333,6 +8336,11 @@ xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
+xmldom@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
+  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
An XML file should be able to define Codecast layout. If several things are in the same zone, it creates a multivisualization (like for the instructions and the variables in the top-left zone) where you can move from one visualization to another.

This is a technical task, it does not add any new behaviour to today's interface. It's a necessary task for the two next tasks:
1. Adding the directives (quicksort, matrix...) to the layout system
2. Have a layout for each screen size