### PR TITLE
[TSC] Use now strictPropertyInitialization

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "noImplicitThis": false, // temporirly disabled, should fix code and remove this line
     "strictFunctionTypes": false, // temporirly disabled, should fix code and remove this line
     "strictNullChecks": false, // temporirly disabled, should fix code and remove this line
-    "strictPropertyInitialization": false, // temporirly disabled, should fix code and remove this line
 
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
Apparently every problem with this check were removed before? I let the build run to check this.