### PR TITLE
Fixes related to bottom controls

### DIFF
--- a/frontend/buffers/Editor.tsx
+++ b/frontend/buffers/Editor.tsx
@@ -67,6 +67,14 @@ export function Editor(props: EditorProps) {
 
     const refEditor = useRef();
 
+    const scrollOnLastLines = () => {
+        const ace = editor.current;
+        const cursorDistanceToBottom = ace.renderer.$size.scrollerHeight + ace.renderer.session.getScrollTop() - ace.renderer.$cursorLayer.getPixelPosition().top;
+        if (cursorDistanceToBottom < 120) {
+            ace.renderer.session.setScrollTop(ace.renderer.session.getScrollTop() + 120 - cursorDistanceToBottom);
+        }
+    }
+
     /*
       Performance fix: Ace fires many redundant selection events, so we wait
       until the next animation frame before querying the selection and firing
@@ -86,6 +94,8 @@ export function Editor(props: EditorProps) {
             console.log('new selection', selection.current, selection_);
             selection.current = selection_;
             props.onSelect(selection_);
+            // Try to scroll if needed
+            scrollOnLastLines();
         });
     };
 
@@ -269,6 +279,7 @@ export function Editor(props: EditorProps) {
             dragEnabled: true,
         });
         editor.current.setOption("scrollPastEnd", 0.1);
+        editor.current.renderer.setScrollMargin(0, 80);
 
         const {onInit, onSelect, onEdit} = props;
         if (typeof onInit === 'function') {

--- a/frontend/tralalere/tralalere.scss
+++ b/frontend/tralalere/tralalere.scss
@@ -281,6 +281,7 @@ $tralalere-red: #FF3C11;
   border-radius: 15px;
   overflow: hidden;
   background: rgba(255,0,0,0);
+  z-index: 1;
 }
 .blockly-flyout-wrapper-bottom {
   position: absolute;

--- a/frontend/tralalere/tralalere.scss
+++ b/frontend/tralalere/tralalere.scss
@@ -188,6 +188,7 @@ $tralalere-red: #FF3C11;
     min-width: 0;
     display: flex;
     flex-direction: column;
+    z-index: 1;
   }
 
   .tralalere-visualization {


### PR DESCRIPTION
This pull request fixes two issues :
* On Blockly, if a block in the toolbox is right at the bottom of the screen, it is covered by the `div.tralalere-controls` (even though it is not visually covered, clicks are still intercepted). A simple CSS fix is just to add a `z-index: 1;`.
* On Python, while writing, the bottom lines can be covered with the bottom controls, and the user has to scroll manually. The Ace Editor doesn't seem to have an option for it, so a new function simply checks how far the cursor is from the bottom, and scrolls if needed to keep the cursor 120px away from the bottom, and hence keep it out of the controls bottom section.