### PR TITLE
Fix block count for some Scratch blocks

### DIFF
--- a/frontend/stepper/js/index.ts
+++ b/frontend/stepper/js/index.ts
@@ -218,6 +218,52 @@ export const hasBlockPlatform = (platform: CodecastPlatform) => {
     return CodecastPlatform.Blockly === platform || CodecastPlatform.Scratch === platform;
 };
 
+const getBlockCount = function (block, context: QuickAlgoLibrary) {
+    // How many "blocks" a specific block counts towards the total
+
+    // Block counts extra
+    if (context.blocklyHelper?.blockCounts && typeof context.blocklyHelper.blockCounts[block.type] == 'number') {
+        return context.blocklyHelper.blockCounts[block.type];
+    }
+
+    if (block.type == 'robot_start') {
+        // Program start block
+        return 0;
+    }
+
+    if (context.blocklyHelper?.scratchMode) {
+        // Don't count insertion markers (shadows when moving a block)
+        if (block.isInsertionMarker_) {
+            return 0;
+        }
+        // Don't count placeholders
+        if (block.type.substring(0, 12) == 'placeholder_') {
+            return 0;
+        }
+        // Counting is tricky because some blocks in Scratch don't count in Blockly
+        if (block.parentBlock_) {
+            // There's a parent (container) block
+            if ((block.type == 'math_number' && block.parentBlock_.type == 'control_repeat') ||
+                (block.type == 'data_variablemenu' &&
+                    (block.parentBlock_.type == 'data_variable' ||
+                        block.parentBlock_.type == 'data_setvariableto' ||
+                        block.parentBlock_.type == 'data_changevariableby'))) {
+                return 0;
+            }
+        } else {
+            if (block.type == 'data_variablemenu') {
+                return 0;
+            }
+        }
+        if (block.type == 'data_itemoflist' || block.type == 'data_replaceitemoflist') {
+            // Count one extra for these ones
+            return 2;
+        }
+    }
+
+    return 1;
+}
+
 export const getBlocklyBlocksUsage = function (answer, context: QuickAlgoLibrary) {
     if (!answer || !answer.blockly) {
         return {
@@ -231,11 +277,8 @@ export const getBlocklyBlocksUsage = function (answer, context: QuickAlgoLibrary
     const blocks = getBlocksFromXml(answer.blockly);
     let blocksUsed = 0;
     for (let i = 0; i < blocks.length; i++) {
-        blocksUsed++;
         let block = blocks[i];
-        if (context.blocklyHelper && context.blocklyHelper.blockCounts && typeof context.blocklyHelper.blockCounts[block.type] != 'undefined') {
-            blocksUsed += context.blocklyHelper.blockCounts[block.type] - 1;
-        }
+        blocksUsed += getBlockCount(block, context);
     }
 
     const limitations = (context.infos.limitedUses ? blocklyFindLimited(blocks, context.infos.limitedUses, context) : []) as {type: string, name: string, current: number, limit: number}[];
@@ -243,7 +286,7 @@ export const getBlocklyBlocksUsage = function (answer, context: QuickAlgoLibrary
     log.getLogger('blockly_runner').debug('limitations', limitations);
 
     return {
-        blocksCurrent: blocksUsed - 1,
+        blocksCurrent: blocksUsed,
         limitations,
     };
 };


### PR DESCRIPTION
Fix the block count for some Scratch blocks.

While at it, I extracted the logic into a function, and added to ignore `robot_start`, meaning we don't need to put a -1 to the blocks used.