### PR TITLE
[Fix] Each fixture should have its own image path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -164,9 +164,9 @@ module.exports = (env, argv) => {
                                 context: 'public',
                                 publicPath: './build/',
                                 name(resourcePath) {
-                                    const matches = /.+task\/fixtures\/[\w_]+\/(.*)/ig.exec(resourcePath);
+                                    const matches = /.+task\/fixtures\/([\w_\-]+)\/(.*)/ig.exec(resourcePath);
 
-                                    return 'images/' + matches[1];
+                                    return 'images/' + matches[1] + '/' + matches[2];
                                 },
                             }
                         }


### PR DESCRIPTION
Fix a bug where two fixtures have same image name but different image content (icon.png)