### PR TITLE
[Fix] Forward promise reject to quickalgo executor root so that when …

### DIFF
--- a/frontend/stepper/api.ts
+++ b/frontend/stepper/api.ts
@@ -506,7 +506,7 @@ export function createQuickAlgoLibraryExecutor(stepperContext: StepperContext) {
         }
 
         const makeLibraryCall = () => {
-            return new Promise(resolve => {
+            return new Promise((resolve, reject) => {
                 let callbackArguments = [];
                 let result = context[module][action].apply(context, [...args, function (a) {
                     log.getLogger('quickalgo_executor').debug('[quickalgo_executor] receive callback', arguments);
@@ -523,7 +523,8 @@ export function createQuickAlgoLibraryExecutor(stepperContext: StepperContext) {
                             log.getLogger('quickalgo_executor').debug('[quickalgo_executor] returned element', module, action, argumentResult);
                             // Use context.waitDelay to transform result to primitive when the library uses generators
                             context.waitDelay(resolve, argumentResult);
-                        });
+                        })
+                        .catch(reject)
                 }
             });
         }


### PR DESCRIPTION
…in printer lib we throw an error in commonRead, it is caught by the stepper and displayed as an execution error