### PR TITLE
[Fix] Smart contract JSON detection

### DIFF
--- a/frontend/task/libs/smart_contract/smart_contract_lib.ts
+++ b/frontend/task/libs/smart_contract/smart_contract_lib.ts
@@ -129,8 +129,11 @@ export class SmartContractLib extends QuickAlgoLibrary {
 
     getErrorFromTestResult(testResult: TaskSubmissionServerTestResult): LibraryTestResult {
         try {
-            const logLastLine = testResult.log.trim().split("\n").pop();
-            const output = JSON.parse(logLastLine);
+            const testResultSplit = testResult.log.trim().split("\n");
+            const jsonFirstIndex = testResultSplit.findIndex(line => line.trim().startsWith('{'));
+            const testResultJson = testResultSplit.slice(jsonFirstIndex).join("\n");
+
+            const output = JSON.parse(testResultJson);
 
             const log = output.log;
             if (output.error && log.length) {


### PR DESCRIPTION
Fix the smart contract JSON detection from the checker output, by looking for the first line starting with a `{` and taking everything after as the JSON data. (In the future, the checker will output the JSON directly from the second line, instead of putting the feedback in plain text before.)