### PR TITLE
Add randomTaskVariants parameter

### DIFF
--- a/frontend/common/actionTypes.ts
+++ b/frontend/common/actionTypes.ts
@@ -17,5 +17,7 @@ export enum ActionTypes {
     PlatformChanged = 'Platform.Changed',
     CanChangePlatformChanged = 'CanChangePlatform.Changed',
 
+    TaskVariantChanged = 'TaskVariant.Changed',
+
     WindowResized = 'Window.Resized'
 }

--- a/frontend/common/options.ts
+++ b/frontend/common/options.ts
@@ -167,6 +167,11 @@ export default function(bundle: Bundle) {
         state.options.canChangePlatform = canChangePlatform;
     });
 
+    bundle.defineAction(ActionTypes.TaskVariantChanged);
+    bundle.addReducer(ActionTypes.TaskVariantChanged, (state, { payload: { variant } }) => {
+        state.options.taskVariant = variant;
+    });
+
     bundle.addSaga(function* () {
         // @ts-ignore
         yield* takeEvery(ActionTypes.PlatformChanged, function* ({payload: {reloadTask}}) {

--- a/frontend/store.ts
+++ b/frontend/store.ts
@@ -91,6 +91,7 @@ export interface CodecastOptions {
     randomizeTestsOrder?: boolean,
     ioMode: IoMode,
     taskVariant?: string,
+    randomTaskVariants?: number,
 }
 
 export interface Panes {

--- a/frontend/task/platform/platform.ts
+++ b/frontend/task/platform/platform.ts
@@ -44,6 +44,7 @@ import {appSelect} from '../../hooks';
 import {ActionTypes as LayoutActionTypes} from '../layout/actionTypes';
 import {LayoutView} from '../layout/layout';
 import {quickAlgoLibraries} from '../libs/quickalgo_libraries';
+import {ActionTypes} from '../../common/actionTypes';
 
 let getTaskAnswer: () => Generator;
 let getTaskState: () => Generator;
@@ -321,6 +322,16 @@ function* taskLoadEventSaga ({payload: {views: _views, success, error}}: ReturnT
         }
     }
     yield* put(platformTaskRandomSeedUpdated(randomSeed));
+
+    const taskVariant = yield* appSelect(state => state.options.taskVariant);
+    const randomTaskVariants = yield* appSelect(state => state.options.randomTaskVariants);
+    if (undefined === taskVariant && undefined !== randomTaskVariants) {
+        const newTaskVariant = 'v' + (parseInt(randomSeed) % randomTaskVariants + 1);
+        yield* put({
+            type: ActionTypes.TaskVariantChanged,
+            payload: { variant: newTaskVariant }
+        });
+    };
 
     let level = yield* appSelect(state => state.task.currentLevel);
     if (!level) {


### PR DESCRIPTION
Add a randomTaskVariants Codecast parameter, which is an optional integer.

If present, and no variant is specified (currently in the URL), Codecast will pick a random variant `vX` where `X` is picked depending on the `randomSeed` passed by the platform.