### PR TITLE
doc: use conceptsFill instead of replacing

### DIFF
--- a/frontend/task/documentation/doc.ts
+++ b/frontend/task/documentation/doc.ts
@@ -199,8 +199,13 @@ function getConceptsFromLanguage(hasTaskInstructions: boolean, state: AppStore) 
         }
 
         if (DocumentationLanguage.C !== language) {
-            allConcepts = window.getConceptViewerBaseConcepts(baseConceptUrl);
-            allConcepts = window.conceptsFill(context.getConceptList(), allConcepts);
+            const baseConcepts = window.getConceptViewerBaseConcepts(baseConceptUrl);
+            // Take concepts from the library first
+            allConcepts = context.getConceptList();
+            // Add base concepts not in the library
+            allConcepts = allConcepts.concat(baseConcepts.filter((concept) => allConcepts.find((c) => c.id === concept.id) === undefined));
+            // Fill library concepts with information from base concepts if needed
+            allConcepts = window.conceptsFill(allConcepts, baseConcepts);
 
             concepts = getConceptsFromBlocks(context.infos.includeBlocks, allConcepts, context.getNotionsList());
             const disabledConcepts = context.conceptDisabledList ? context.conceptDisabledList : [];

--- a/frontend/task/documentation/doc.ts
+++ b/frontend/task/documentation/doc.ts
@@ -200,12 +200,7 @@ function getConceptsFromLanguage(hasTaskInstructions: boolean, state: AppStore) 
 
         if (DocumentationLanguage.C !== language) {
             allConcepts = window.getConceptViewerBaseConcepts(baseConceptUrl);
-            for (let concept of context.getConceptList()) {
-                if (concept.id && -1 !== allConcepts.findIndex(otherConcept => otherConcept.id === concept.id)) {
-                    allConcepts.splice(allConcepts.findIndex(otherConcept => otherConcept.id === concept.id), 1);
-                }
-                allConcepts.push(concept);
-            }
+            allConcepts = window.conceptsFill(context.getConceptList(), allConcepts);
 
             concepts = getConceptsFromBlocks(context.infos.includeBlocks, allConcepts, context.getNotionsList());
             const disabledConcepts = context.conceptDisabledList ? context.conceptDisabledList : [];


### PR DESCRIPTION
When a library defines concepts, use conceptsFill instead of overwriting the concepts. This way a library can, for instance, not specify the URL for base concepts, and have the URL defined by the usual base concept URL logic, but still specify things like categories for those concepts.