### PR TITLE
[Fix] Variants are now numbers and not vX

### DIFF
--- a/frontend/task/platform/platform.ts
+++ b/frontend/task/platform/platform.ts
@@ -326,7 +326,7 @@ function* taskLoadEventSaga ({payload: {views: _views, success, error}}: ReturnT
     const taskVariant = yield* appSelect(state => state.options.taskVariant);
     const randomTaskVariants = yield* appSelect(state => state.options.randomTaskVariants);
     if (undefined === taskVariant && undefined !== randomTaskVariants) {
-        const newTaskVariant = 'v' + (parseInt(randomSeed) % randomTaskVariants + 1);
+        const newTaskVariant = parseInt(randomSeed) % randomTaskVariants + 1;
         yield* put({
             type: ActionTypes.TaskVariantChanged,
             payload: { variant: newTaskVariant }


### PR DESCRIPTION
randomTaskVariants code was written when variants were a string such as 'v4', while now they are identified by numbers.