### PR TITLE
Libs can have lower priority on languageStrings

### DIFF
--- a/frontend/task/libs/debug/debug_lib.tsx
+++ b/frontend/task/libs/debug/debug_lib.tsx
@@ -26,7 +26,7 @@ export class DebugLib extends QuickAlgoLibrary {
     constructor (display, infos) {
         super(display, infos);
 
-        this.setLocalLanguageStrings(localLanguageStrings);
+        this.setLocalLanguageStrings(localLanguageStrings, true);
 
         this.debug = {
             log: this.log,

--- a/frontend/task/libs/printer/printer_lib.tsx
+++ b/frontend/task/libs/printer/printer_lib.tsx
@@ -204,7 +204,7 @@ export class PrinterLib extends QuickAlgoLibrary {
 
         this.libInstance = printerLibInstance++;
 
-        this.setLocalLanguageStrings(localLanguageStrings);
+        this.setLocalLanguageStrings(localLanguageStrings, true);
 
         const conceptBaseUrl = (window.location.protocol == 'https:' ? 'https:' : 'http:') + '//'
             + 'static4.castor-informatique.fr/help/printer_codecast.html';

--- a/frontend/task/libs/quickalgo_library.ts
+++ b/frontend/task/libs/quickalgo_library.ts
@@ -80,17 +80,22 @@ export abstract class QuickAlgoLibrary {
     }
 
     // Set the localLanguageStrings for this context
-    setLocalLanguageStrings(localLanguageStrings) {
+    setLocalLanguageStrings(localLanguageStrings, doNotReplace = false) {
         log.getLogger('libraries').debug('set local language strings', localLanguageStrings);
         const stringsLanguage = window.stringsLanguage && window.stringsLanguage in localLanguageStrings ? window.stringsLanguage : "fr";
 
         if (typeof window.languageStrings != "object") {
             console.error("window.languageStrings is not an object");
         } else { // merge translations
-            window.languageStrings = merge(
-                window.languageStrings,
-                localLanguageStrings[stringsLanguage],
-            );
+            window.languageStrings = doNotReplace ?
+                merge(
+                    localLanguageStrings[stringsLanguage],
+                    window.languageStrings,
+                ) :
+                merge(
+                    window.languageStrings,
+                    localLanguageStrings[stringsLanguage],
+                );
         }
         this.strings = window.languageStrings;
 


### PR DESCRIPTION
Add an option `doNotReplace` to `setLocalLanguageStrings`, for a library to declare their language strings as "lower priority" and to be used only if no other library declares them. Prevents for instance the debug library from replacing the `startingBlockName` from the main library.