### PR TITLE
[Fix] Undefined context or answer sometimes

### DIFF
--- a/frontend/stepper/js/index.ts
+++ b/frontend/stepper/js/index.ts
@@ -21,6 +21,8 @@ let originalFireNow;
 let originalSetBackgroundPathVertical_;
 
 export function* loadBlocklyHelperSaga(context: QuickAlgoLibrary) {
+    if(!context) { return; }
+
     let blocklyHelper;
 
     if (context && context.blocklyHelper && !context.blocklyHelper.fake) {

--- a/frontend/task/index.ts
+++ b/frontend/task/index.ts
@@ -933,6 +933,9 @@ export default function (bundle: Bundle) {
 
         yield* takeEvery(platformAnswerLoaded, function*({payload: {answer}}) {
             log.getLogger('task').debug('Platform answer loaded', answer);
+            if(!answer) {
+                return;
+            }
             const state = yield* appSelect();
             if (state.options.tabsEnabled) {
                 yield* call(createSourceBufferFromDocument, answer.document);


### PR DESCRIPTION
Avoid crashing completely when :
* context is null when calling loadBlocklyHelperSaga
* answer is undefined when platformAnswerLoaded