### PR TITLE
Ignore node_modules when watching

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -241,6 +241,9 @@ module.exports = (env, argv) => {
             colors: true,
             modules: false,
             moduleTrace: false,
+        },
+        watchOptions: {
+            ignored: /node_modules/,
         }
     };
 }


### PR DESCRIPTION
Ignore `node_modules` when watching, as this can make the number of watchers explode.