### PR TITLE
Platform changes (done -> stay)

### DIFF
--- a/frontend/submission/task_submission.tsx
+++ b/frontend/submission/task_submission.tsx
@@ -2,6 +2,7 @@ import {apply, call, cancel, cancelled, fork, put, race, spawn} from "typed-redu
 import {ActionTypes as StepperActionTypes, stepperDisplayError} from "../stepper/actionTypes";
 import log from "loglevel";
 import {
+    getNextLevelIndex,
     platformApi,
     PlatformTaskGradingParameters,
     PlatformTaskGradingResult,
@@ -145,13 +146,9 @@ class TaskSubmissionExecutor {
 
         const finalScore = worstRate;
         if (finalScore > 0) {
-            const nextVersion = yield* call(taskGetNextLevelToIncreaseScore, level);
-
-            const isTralalere = yield* appSelect(state => 'tralalere' == state.options.app);
-            let stay = finalScore < 1;
-            if (isTralalere) {
-                stay = stay || null !== nextVersion;
-            }
+            const levels = yield* appSelect(state => state.platform.levels);
+            const nextLevel = getNextLevelIndex(levels, level);
+            let stay = finalScore < 1 || null !== nextLevel;
 
             yield* call([platformApi, platformApi.validate], stay ? 'stay' : 'done');
             if (1 <= finalScore && window.SrlLogger) {

--- a/frontend/task/TaskLevelTabs.tsx
+++ b/frontend/task/TaskLevelTabs.tsx
@@ -15,6 +15,8 @@ export function TaskLevelTabs() {
     const levels = useAppSelector(state => state.platform.levels);
     const [lockedDialogOpen, setLockedDialogOpen] = useState(false);
     const [levelToChange, setLevelToChange] = useState<TaskLevelName>(null);
+    // Option called "Score immédiat" in the platform
+    const taskParamsFullFeedback = useAppSelector(state => state.platform.taskParams.fullFeedback);
 
     const bypassLock = window.location.protocol === 'file:' || -1 !== ['localhost', '127.0.0.1', '0.0.0.0', 'lvh.me'].indexOf(window.location.hostname);
 
@@ -60,7 +62,7 @@ export function TaskLevelTabs() {
                         <span>{getMessage('TASK_LEVEL')}</span>
                         <Stars
                             starsCount={levelScoringData[levelData.level].stars}
-                            rating={levelData.score}
+                            rating={false !== taskParamsFullFeedback ? levelData.score : null}
                             disabled={levelData.locked}
                         />
                     </a>

--- a/frontend/task/dialog/TaskSuccessDialog.tsx
+++ b/frontend/task/dialog/TaskSuccessDialog.tsx
@@ -4,9 +4,9 @@ import {useAppSelector} from "../../hooks";
 import {useDispatch} from "react-redux";
 import {getMessage} from "../../lang";
 import {taskLevelsList} from "../platform/platform_slice";
-
 import {callPlatformValidate} from '../../submission/submission_actions';
 import {taskChangeLevel} from '../task_actions';
+import {getNextLevelIndex} from '../platform/platform';
 
 export interface TaskSuccessDialogProps {
     onClose: () => void,
@@ -21,20 +21,14 @@ export function TaskSuccessDialog(props: TaskSuccessDialogProps) {
     const dispatch = useDispatch();
 
     let currentLevelFinished = false;
-    let currentLevelIndex = null;
-    let hasNextLevel = false;
     let nextLevel = null;
     if (currentLevel && currentLevel in levels) {
         currentLevelFinished = (levels[currentLevel].score >= 1);
-        currentLevelIndex = taskLevelsList.indexOf(currentLevel);
-        for (let level = currentLevelIndex + 1; level < taskLevelsList.length; level++) {
-            if (taskLevelsList[level] in levels) {
-                hasNextLevel = true;
-                nextLevel = level;
-                break;
-            }
+        if (currentLevelFinished) {
+            nextLevel = getNextLevelIndex(levels, currentLevel);
         }
     }
+    const hasNextLevel = null !== nextLevel;
 
     let intermediateMessage = null;
     let nextAction = 'next-level';

--- a/frontend/task/platform/platform.ts
+++ b/frontend/task/platform/platform.ts
@@ -30,8 +30,8 @@ import {
     platformSaveAnswer,
     platformSaveScore,
     platformTaskRandomSeedUpdated,
-    platformTokenUpdated,
-    TaskLevelName,
+    platformTokenUpdated, TaskLevel,
+    TaskLevelName, taskLevelsList,
 } from "./platform_slice";
 import {Effect} from "@redux-saga/types";
 import log from "loglevel";
@@ -520,6 +520,17 @@ function getTopLevel(levels: TaskLevelName[]) {
     });
 
     return sortedLevels[sortedLevels.length - 1];
+}
+
+export function getNextLevelIndex(levels: {[key: string]: TaskLevel}, currentLevel: TaskLevelName): number|null {
+    const currentLevelIndex = taskLevelsList.indexOf(currentLevel);
+    for (let level = currentLevelIndex + 1; level < taskLevelsList.length; level++) {
+        if (taskLevelsList[level] in levels) {
+            return level;
+        }
+    }
+
+    return null;
 }
 
 export interface PlatformTaskGradingParameters {

--- a/frontend/task/platform/platform_slice.ts
+++ b/frontend/task/platform/platform_slice.ts
@@ -22,12 +22,24 @@ export interface PlatformState {
     taskRandomSeed: string,
     taskToken: string,
     levels: {[key: string]: TaskLevel},
+    taskParams: PlatformTaskParams,
+}
+
+export interface PlatformTaskParams {
+    randomSeed: string,
+    options: any,
+    minScore: number,
+    maxScore: number,
+    noScore: number,
+    supportsTabs?: boolean,
+    fullFeedback?: boolean,
 }
 
 export const platformInitialState = {
     taskRandomSeed: null,
     taskToken: null,
     levels: {},
+    taskParams: {},
 } as PlatformState;
 
 export const getDefaultTaskLevel = (level: TaskLevelName) => {
@@ -92,11 +104,15 @@ export const platformSlice = createSlice({
             const taskLevel = state.levels[action.payload.level];
             taskLevel.answer = action.payload.answer;
         },
+        platformTaskParamsUpdated(state: PlatformState, action: PayloadAction<PlatformTaskParams>) {
+            state.taskParams = action.payload;
+        },
     },
 });
 
 export const {
     platformTaskRandomSeedUpdated,
+    platformTaskParamsUpdated,
     platformTokenUpdated,
     platformSetTaskLevels,
     platformSaveScore,

--- a/frontend/tralalere/TralalereApp.tsx
+++ b/frontend/tralalere/TralalereApp.tsx
@@ -33,6 +33,7 @@ import {toHtml} from '../utils/sanitize';
 import {getTaskSuccessMessageSelector} from '../task/instructions/instructions';
 import {InstructionsContext} from '../contexts';
 import {DebugDialog} from '../task/dialog/DebugDialog';
+import {getNextLevelIndex} from '../task/platform/platform';
 
 const layoutEditorStyle = {backgroundImage: `url(${window.modulesPath + 'img/algorea/crane/editor-cross.png'}`};
 
@@ -66,21 +67,14 @@ export function TralalereApp() {
 
     const levels = useAppSelector(state => state.platform.levels);
     const currentLevel = useAppSelector(state => state.task.currentLevel);
-    let hasNextLevel = false;
     let nextLevel = null;
     if (currentLevel && currentLevel in levels) {
         const currentLevelFinished = (levels[currentLevel].score >= 1);
         if (currentLevelFinished) {
-            const currentLevelIndex = taskLevelsList.indexOf(currentLevel);
-            for (let level = currentLevelIndex + 1; level < taskLevelsList.length; level++) {
-                if (taskLevelsList[level] in levels) {
-                    hasNextLevel = true;
-                    nextLevel = level;
-                    break;
-                }
-            }
+            nextLevel = getNextLevelIndex(levels, currentLevel);
         }
     }
+    const hasNextLevel = null !== nextLevel;
 
     const [nextLevelOpen, setNextLevelOpen] = useState(false);
     const displayDebug = useAppSelector(state => 0 < state.task.state?.debug?.linesLogged?.length);


### PR DESCRIPTION
Mathias, 14 février 2024 :
- sur la plateforme Castor si on a scoreImmediate à false, plutôt que de ne pas appeler gradeAnswer, on transmet l'info au sujet via getTaskParams()
- côté sujet, si getTaskParams dit scoreImmediate à false, on ne met jamais les étoiles en jaune
- a priori pas besoin de désactiver (pour l'instant) côté plateforme le système qui remplace done par stay si score != max. On va éviter de casser qqc
- mais dans le sujet on n'envoie done que si on vient de valider qqc qui donne le score max (à elle seule, en ignorant le score qu'on avait avant sur le sujet). Mais si on a déjà le score max et qu'on valide une version inférieure, ça n'envoie pas done (mais stay).