### PR TITLE
[Fix] When we change the level, first reload the context and then rel…

### DIFF
--- a/frontend/task/index.ts
+++ b/frontend/task/index.ts
@@ -116,6 +116,7 @@ import {submissionCancel} from '../submission/submission_actions';
 import {createSourceBufferFromDocument} from '../buffers';
 import {RECORDING_FORMAT_VERSION} from '../version';
 import {Screen} from '../common/screens';
+import {DeferredPromise} from '../utils/app';
 
 // @ts-ignore
 if (!String.prototype.format) {
@@ -528,6 +529,12 @@ function* taskChangeLevelSaga({payload}: ReturnType<typeof taskChangeLevel>) {
     const taskToken = getTaskTokenForLevel(newLevel, randomSeed);
     yield* put(platformTokenUpdated(taskToken));
 
+    const deferredPromise = new DeferredPromise();
+    yield* put(updateCurrentTestId({testId: 0, record: false, recreateContext: true, callback: deferredPromise.resolve}));
+
+    // Wait the creation of the new context before setting answer because getDefaultSourceCode depends on the context
+    yield deferredPromise.promise;
+
     const currentTask = state.task.currentTask;
     // Reload answer
     let newLevelAnswer = yield* appSelect(state => state.platform.levels[newLevel].answer);
@@ -540,8 +547,6 @@ function* taskChangeLevelSaga({payload}: ReturnType<typeof taskChangeLevel>) {
         }
     }
     yield* put(platformAnswerLoaded(newLevelAnswer));
-
-    yield* put(updateCurrentTestId({testId: 0, record: false, recreateContext: true}));
 
     yield* call(taskLevelLoadedSaga);
 }
@@ -604,6 +609,10 @@ function* taskUpdateCurrentTestIdSaga({payload}) {
         if (newTaskResetDone !== state.task.resetDone) {
             yield* put(taskResetDone(newTaskResetDone));
         }
+    }
+
+    if (payload.callback) {
+        yield* call(payload.callback);
     }
 }
 

--- a/frontend/task/index.ts
+++ b/frontend/task/index.ts
@@ -71,7 +71,7 @@ import {platformAnswerGraded, platformAnswerLoaded, taskGradeAnswerEvent,} from 
 import {
     getDefaultTaskLevel,
     platformSaveAnswer,
-    platformSetTaskLevels,
+    platformSetTaskLevels, platformTaskParamsUpdated,
     platformTokenUpdated, platformUnlockLevel,
     TaskLevelName,
     taskLevelsList
@@ -184,6 +184,9 @@ function* taskLoadSaga(app: App, action) {
             yield* put(currentTaskChangePredefined(selectedTask));
         }
     }
+
+    const taskParams = yield* call(platformApi.getTaskParams, null, null);
+    yield* put(platformTaskParamsUpdated(taskParams));
 
     // yield* put(hintsLoaded([
     //     {content: 'aazazaz', minScore: 0},

--- a/frontend/task/platform/platform.ts
+++ b/frontend/task/platform/platform.ts
@@ -371,7 +371,6 @@ function* taskLoadEventSaga ({payload: {views: _views, success, error}}: ReturnT
         }
     }
     yield* put(platformTaskRandomSeedUpdated(randomSeed));
-    yield* put(platformTaskParamsUpdated(taskParams));
 
     const taskVariant = yield* appSelect(state => state.options.taskVariant);
     const randomTaskVariants = yield* appSelect(state => state.options.randomTaskVariants);
@@ -430,7 +429,7 @@ export function* taskGradeAnswerEventSaga ({payload: {answer, success, error, si
     try {
         const taskLevels = yield* appSelect(state => state.platform.levels);
         log.getLogger('tests').debug('task levels', taskLevels);
-        const {minScore, maxScore} = yield* appSelect(state => state.platform.taskParams);
+        const {minScore, maxScore} = yield* call(platformApi.getTaskParams, null, null);
         if (taskLevels && Object.keys(taskLevels).length) {
             const versionsScore = {};
             const currentLevel = yield getTaskLevel();

--- a/frontend/task/task_slice.ts
+++ b/frontend/task/task_slice.ts
@@ -136,7 +136,7 @@ export const taskSlice = createSlice({
             state.previousTestId = state.currentTestId;
             state.currentTestId = action.payload.newTestId;
         },
-        updateCurrentTestId(state: TaskState, action: PayloadAction<{testId: number, record?: boolean, recreateContext?: boolean, withoutContextState?: boolean, keepSubmission?: boolean}>) {
+        updateCurrentTestId(state: TaskState, action: PayloadAction<{testId: number, record?: boolean, recreateContext?: boolean, withoutContextState?: boolean, keepSubmission?: boolean, callback?: () => void}>) {
             state.previousTestId = state.currentTestId;
             state.currentTestId = action.payload.testId;
         },


### PR DESCRIPTION
…oad the answer because the default source code depends on the context