### PR TITLE
Make platform.validate workflow identical to Quickalgo by subscribing…

### DIFF
--- a/frontend/task/platform/actionTypes.ts
+++ b/frontend/task/platform/actionTypes.ts
@@ -82,3 +82,9 @@ export const taskGetResourcesPost = createAction('taskEventGetResourcesPost', (r
         callback,
     },
 }));
+
+export const platformValidateEvent = createAction('platformEventValidate', (mode: string) => ({
+    payload: {
+        mode,
+    },
+}));

--- a/frontend/task/platform/task_channel.ts
+++ b/frontend/task/platform/task_channel.ts
@@ -58,7 +58,7 @@ function makeTask (emit) {
         load: function (views, success, error) {
             emit(taskLoadEvent(views, success ?? (() => {}), error ?? (() => {})));
         },
-        gradeAnswer: function (answer, answerToken, success, error, silent = false) {
+        gradeAnswer: function (answer, answerToken, success, error, silent = true) {
             emit(taskGradeAnswerEvent(answer, answerToken, success ?? (() => {}), error ?? (() => {}), silent));
         },
     };


### PR DESCRIPTION
… a custom platform helper to handle validation. task.gradeAnswer should be silent by default (do not update stars nor display task success popup)