### PR TITLE
[Fix] On server task we should not do platform.subscribe to receive e…

### DIFF
--- a/frontend/task/index.ts
+++ b/frontend/task/index.ts
@@ -47,7 +47,7 @@ import BlocksBundle from "./blocks/blocks";
 import PlatformBundle, {
     getTaskAnswerAggregated,
     platformApi,
-    setPlatformBundleParameters,
+    setPlatformBundleParameters, subscribePlatformHelper,
     taskGradeAnswerEventSaga
 } from "./platform/platform";
 import {ActionTypes as LayoutActionTypes} from "./layout/actionTypes";
@@ -95,7 +95,7 @@ import {hasBlockPlatform} from '../stepper/platforms';
 import {LibraryTestResult} from './libs/library_test_result';
 import {QuickAlgoLibrary} from './libs/quickalgo_library';
 import {getMessage, Languages} from '../lang';
-import {TaskServer, TaskTest} from './task_types';
+import {isServerTask, TaskServer, TaskTest} from './task_types';
 import {extractTestsFromTask} from '../submission/tests';
 import {taskChangeLevel, taskLoad} from './task_actions';
 import {App, Codecast} from '../app_types';
@@ -272,9 +272,11 @@ function* taskLoadSaga(app: App, action) {
     //     },
     // ]));
 
-
-
     const currentTask = yield* appSelect(state => state.task.currentTask);
+    if (!isServerTask(currentTask)) {
+        yield* call(subscribePlatformHelper);
+    }
+
     if (currentTask) {
         if (currentTask?.gridInfos?.documentationOpenByDefault) {
             yield* put({type: CommonActionTypes.AppSwitchToScreen, payload: {screen: Screen.DocumentationSmall}});

--- a/frontend/task/platform/platform.ts
+++ b/frontend/task/platform/platform.ts
@@ -121,12 +121,6 @@ function* linkTaskPlatformSaga() {
 
     platformApi = makePlatformAdapter(window.platform);
 
-    const platformHelperChannel = yield* call(makePlatformHelperChannel);
-    const platformHelper = ((yield* take(platformHelperChannel)) as {platformHelper: any}).platformHelper;
-    platformApi.subscribe(platformHelper);
-
-    yield* takeEvery(platformHelperChannel, dispatchActionToStore);
-
     window.onerror = sendErrorLog;
 
     const taskChannel = yield* call(makeTaskChannel);
@@ -143,6 +137,13 @@ function* linkTaskPlatformSaga() {
     window.taskGetResourcesPost = (res, callback) => {
         Codecast.environments['main'].store.dispatch(taskGetResourcesPost(res, callback));
     };
+}
+
+export function* subscribePlatformHelper() {
+    const platformHelperChannel = yield* call(makePlatformHelperChannel);
+    const platformHelper = ((yield* take(platformHelperChannel)) as {platformHelper: any}).platformHelper;
+    platformApi.subscribe(platformHelper);
+    yield* takeEvery(platformHelperChannel, dispatchActionToStore);
 }
 
 export function isTaskPlatformLinked(): boolean {

--- a/frontend/task/task_types.ts
+++ b/frontend/task/task_types.ts
@@ -222,8 +222,8 @@ export interface TaskServer extends TaskNormalized {
 
 export type Task = QuickalgoTask & Partial<TaskServer>;
 
-export function isServerTask(object: Task): boolean {
-    return null !== object.id && undefined !== object.id;
+export function isServerTask(object: Task|null): boolean {
+    return (object && null !== object.id && undefined !== object.id) || window.PEMTaskMetaData;
 }
 
 export function isServerTest(object: TaskTest): boolean {


### PR DESCRIPTION
…vents sent by platform.trigger. It's only done on client tasks on Quickalgo, not on Task Platform