### PR TITLE
Use cache only in case of platformValidateEvent (dispatched by platfo…

### DIFF
--- a/frontend/submission/task_submission.tsx
+++ b/frontend/submission/task_submission.tsx
@@ -208,12 +208,12 @@ class TaskSubmissionExecutor {
         });
     }
 
-    *executeWithCaching(answerParameters: any[], execute: () => Generator<any, any, any>) {
+    *executeWithCaching(answerParameters: any[], execute: () => Generator<any>, useCache: boolean = false) {
         const serialized = answerParameters.map(e => JSON.stringify(e)).join('§');
         let h1 = murmurhash3_32_gc(serialized, 0);
         const cacheKey = h1 + murmurhash3_32_gc(h1 + serialized, 0); // Extend to 64-bit hash
 
-        if (!(cacheKey in executionsCache)) {
+        if (!(cacheKey in executionsCache) || !useCache) {
             log.getLogger('tests').debug('Executions cache MISS', answerParameters, cacheKey);
             executionsCache[cacheKey] = yield* execute();
         } else {
@@ -240,13 +240,13 @@ class TaskSubmissionExecutor {
     }
 
     *gradeAnswerServer(parameters: PlatformTaskGradingParameters): Generator<any, PlatformTaskGradingResult, any> {
-        const {answer, answerToken, scope} = parameters;
+        let {answer, answerToken, scope, useCache} = parameters;
 
         const answerParameters = [answer, scope];
 
         const self = this;
 
-        return yield* this.executeWithCaching(answerParameters, function* () {
+        const evaluateAnswer = function* () {
             const state = yield* appSelect();
             const platform = answer.platform;
             const userTests = SubmissionExecutionScope.MyTests === scope ? getTaskLevelTests(state).filter(test => TaskTestGroupType.User === test.groupType) : [];
@@ -312,7 +312,9 @@ class TaskSubmissionExecutor {
                     error: message,
                 }
             }
-        });
+        };
+
+        return yield* this.executeWithCaching(answerParameters, evaluateAnswer, useCache);
     }
 
     *gradeAnswerLongPolling(submissionIndex: number, serverSubmission: TaskSubmissionServer, submissionId: string, deferredResult: DeferredPromise<TaskSubmissionServerResult>) {

--- a/frontend/task/platform/actionTypes.ts
+++ b/frontend/task/platform/actionTypes.ts
@@ -71,7 +71,7 @@ export const taskReloadAnswerEvent = createAction('taskEventReloadAnswer', (answ
         options,
     },
 }));
-export const taskGradeAnswerEvent = createAction('taskEventGradeAnswer', (answer, answerToken, success, error, updateScore: boolean, showResult: boolean) => ({
+export const taskGradeAnswerEvent = createAction('taskEventGradeAnswer', (answer, answerToken, success, error, updateScore?: boolean, showResult?: boolean, useCache?: boolean) => ({
     payload: {
         answer,
         answerToken,
@@ -79,6 +79,7 @@ export const taskGradeAnswerEvent = createAction('taskEventGradeAnswer', (answer
         error,
         updateScore,
         showResult,
+        useCache,
     },
 }));
 export const taskGetResourcesPost = createAction('taskEventGetResourcesPost', (resources, callback) => ({

--- a/frontend/task/platform/platform.ts
+++ b/frontend/task/platform/platform.ts
@@ -488,7 +488,7 @@ function* taskLoadEventSaga ({payload: {views: _views, success, error}}: ReturnT
     }
 }
 
-export function* taskGradeAnswerEventSaga ({payload: {answer, answerToken, success, error, updateScore, showResult}}: ReturnType<typeof taskGradeAnswerEvent>) {
+export function* taskGradeAnswerEventSaga ({payload: {answer, answerToken, success, error, updateScore, showResult, useCache}}: ReturnType<typeof taskGradeAnswerEvent>) {
     const state = yield* appSelect();
     if (TaskPlatformMode.RecordingProgress === getTaskPlatformMode(state) && !updateScore) {
         yield* call(success, Number(answer) / recordingProgressSteps, '');
@@ -523,7 +523,7 @@ export function* taskGradeAnswerEventSaga ({payload: {answer, answerToken, succe
                 log.getLogger('tests').debug('info answer', level);
 
                 // Score is between 0 and 1
-                const {score, message, scoreToken} = yield* call([taskGrader, taskGrader.gradeAnswer], {level, answer: answerObject[level], answerToken});
+                const {score, message, scoreToken} = yield* call([taskGrader, taskGrader.gradeAnswer], {level, answer: answerObject[level], answerToken, useCache});
 
                 versionsScore[level] = score;
                 if (level === currentLevel) {
@@ -554,7 +554,7 @@ export function* taskGradeAnswerEventSaga ({payload: {answer, answerToken, succe
             const answerObject = JSON.parse(answer);
 
             // Score is between 0 and 1
-            const {score, message, scoreToken} = yield* call([taskGrader, taskGrader.gradeAnswer], {answer: answerObject, answerToken});
+            const {score, message, scoreToken} = yield* call([taskGrader, taskGrader.gradeAnswer], {answer: answerObject, answerToken, useCache});
             const scoreWithPlatformParameters = minScore + (maxScore - minScore) * score;
 
             if (showResult) {
@@ -620,7 +620,7 @@ function* platformValidateEventSaga({payload: {mode}}: ReturnType<typeof platfor
         const answer = stringify(yield* getTaskAnswerAggregated());
 
         // Grade with updateScore = true and showResult = true
-        yield* call(taskGradeAnswerEventSaga, taskGradeAnswerEvent(answer, null, () => {}, () => {}, true, true));
+        yield* call(taskGradeAnswerEventSaga, taskGradeAnswerEvent(answer, null, () => {}, () => {}, true, true, true));
     }
 }
 
@@ -629,6 +629,7 @@ export interface PlatformTaskGradingParameters {
     answer?: TaskAnswer,
     answerToken?: string,
     scope?: SubmissionExecutionScope,
+    useCache?: boolean,
 }
 
 export interface PlatformTaskGradingResult {


### PR DESCRIPTION
…rm.trigger). In the other cases (platform.validate), do a clean new evaluation because the platform needs a fresh scoreToken